### PR TITLE
[Feat] DIContainer & ScreenFactory 도입

### DIFF
--- a/Run Mile/App/Core/AppDIContainer.swift
+++ b/Run Mile/App/Core/AppDIContainer.swift
@@ -1,0 +1,112 @@
+//
+//  AppDIContainer.swift
+//  Run Mile
+//
+//  Created by Codex on 5/8/26.
+//
+
+import Foundation
+
+
+final class AppDIContainer: ScreenDependencyProviding {
+    private let workoutRepository: WorkoutDataRepository
+    private let shoesRepository: ShoesDataRepository
+    
+    init(
+        workoutRepository: WorkoutDataRepository = WorkoutDataRepositoryImpl(),
+        shoesRepository: ShoesDataRepository = ShoesDataRepositoryImpl()
+    ) {
+        self.workoutRepository = workoutRepository
+        self.shoesRepository = shoesRepository
+    }
+    
+    /// 신발 목록 화면의 상태와 액션을 관리하는 ViewModel을 생성합니다.
+    func makeShoesListViewModel() -> ShoesListViewModel {
+        ShoesListViewModel(
+            useCase: DefaultShoesViewUseCase(
+                repository: shoesRepository,
+                workoutRepository: workoutRepository
+            )
+        )
+    }
+    
+    /// 신발 상세 화면의 상태와 액션을 관리하는 ViewModel을 생성합니다.
+    func makeShoesDetailViewModel(shoes: Shoes) -> ShoesDetailViewModel {
+        ShoesDetailViewModel(
+            useCase: DefaultShoesDetailUseCase(
+                repository: shoesRepository
+            ),
+            shoes: shoes
+        )
+    }
+    
+    /// 신발 추가 화면의 상태와 액션을 관리하는 ViewModel을 생성합니다.
+    func makeAddShoesViewModel() -> AddShoesViewModel {
+        AddShoesViewModel(
+            useCase: DefaultAddShoesUseCase(
+                repository: shoesRepository
+            )
+        )
+    }
+    
+    /// 운동 목록 화면의 상태와 액션을 관리하는 ViewModel을 생성합니다.
+    func makeWorkoutListViewModel() -> WorkoutListViewModel {
+        WorkoutListViewModel(
+            useCase: DefaultHealthDataUseCase(
+                workoutDataRepository: workoutRepository,
+                shoesDataRepository: shoesRepository
+            )
+        )
+    }
+    
+    /// 운동 상세 화면의 상태와 액션을 관리하는 ViewModel을 생성합니다.
+    func makeWorkoutDetailViewModel(workout: Workout) -> WorkoutDetailViewModel {
+        WorkoutDetailViewModel(
+            useCase: DefaultWorkoutDetailUseCase(
+                workoutRepository: workoutRepository
+            ),
+            workout: workout
+        )
+    }
+    
+    /// 운동 기록을 신발에 연결하는 화면의 ViewModel을 생성합니다.
+    func makeChooseShoesViewModel(workouts: [Workout]) -> ChooseShoesViewModel {
+        ChooseShoesViewModel(
+            useCase: DefaultChooseShoesUseCase(
+                repository: shoesRepository
+            ),
+            workouts: workouts
+        )
+    }
+    
+    /// 자동 마일리지 등록 화면의 상태와 액션을 관리하는 ViewModel을 생성합니다.
+    func makeAutoMileageShoesViewModel() -> AutoMileageShoesViewModel {
+        AutoMileageShoesViewModel(
+            useCase: DefaultAddMileageShoesUseCase(
+                shoesRepository: shoesRepository
+            )
+        )
+    }
+    
+    /// 마이페이지 화면의 상태와 액션을 관리하는 ViewModel을 생성합니다.
+    func makeMyPageViewModel() -> MyPageViewModel {
+        MyPageViewModel(
+            useCase: DefaultMyPageUseCase()
+        )
+    }
+    
+    /// 명예의 전당 화면의 상태와 액션을 관리하는 ViewModel을 생성합니다.
+    func makeHOFViewModel() -> HOFViewModel {
+        HOFViewModel(
+            useCase: DefaultHOFUseCase(
+                repository: shoesRepository
+            )
+        )
+    }
+    
+    /// 개발자 정보 화면의 상태와 액션을 관리하는 ViewModel을 생성합니다.
+    func makeInformationViewModel() -> InformationViewModel {
+        InformationViewModel()
+    }
+}
+

--- a/Run Mile/App/Core/Preview/PreviewDIContainer.swift
+++ b/Run Mile/App/Core/Preview/PreviewDIContainer.swift
@@ -1,0 +1,106 @@
+//
+//  PreviewDIContainer.swift
+//  Run Mile
+//
+//  Created by Codex on 5/8/26.
+//
+
+#if DEBUG
+import Foundation
+
+
+final class PreviewDIContainer: ScreenDependencyProviding {
+    /// 신발 목록 Preview용 ViewModel을 샘플 데이터가 주입된 상태로 생성합니다.
+    func makeShoesListViewModel() -> ShoesListViewModel {
+        let viewModel = ShoesListViewModel(
+            useCase: PreviewShoesListUseCase(
+                shoes: PreviewShoesMockData.shoes,
+                monthlyDistance: PreviewShoesMockData.monthlyRunningDistance
+            )
+        )
+        viewModel.shoes = PreviewShoesMockData.shoes
+        viewModel.monthlyDistanceText = String(
+            format: "%.1f km",
+            PreviewShoesMockData.monthlyRunningDistance
+        )
+        return viewModel
+    }
+    
+    /// 신발 상세 Preview용 ViewModel을 샘플 액션 UseCase와 함께 생성합니다.
+    func makeShoesDetailViewModel(shoes: Shoes) -> ShoesDetailViewModel {
+        ShoesDetailViewModel(
+            useCase: PreviewShoesDetailUseCase(),
+            shoes: shoes
+        )
+    }
+    
+    /// 신발 추가 Preview용 ViewModel을 기본 입력값이 채워진 상태로 생성합니다.
+    func makeAddShoesViewModel() -> AddShoesViewModel {
+        let viewModel = AddShoesViewModel(useCase: PreviewAddShoesUseCase())
+        viewModel.selectedBrand = "Nike"
+        viewModel.selectedModel = "Pegasus 41"
+        viewModel.usage = "데일리 러닝"
+        viewModel.goalMileage = "700"
+        return viewModel
+    }
+    
+    /// 운동 목록 Preview용 ViewModel을 샘플 운동 기록이 채워진 상태로 생성합니다.
+    func makeWorkoutListViewModel() -> WorkoutListViewModel {
+        let viewModel = WorkoutListViewModel(useCase: PreviewHealthDataUseCase())
+        let currentMonthWorkouts = Array(PreviewShoesMockData.workouts.prefix(3))
+        let previousMonthWorkouts = Array(PreviewShoesMockData.workouts.suffix(2))
+        viewModel.dateHeaders = [
+            currentMonthWorkouts.first?.date.yearMonth ?? "2026년 5월",
+            previousMonthWorkouts.first?.date.yearMonth ?? "2026년 4월"
+        ]
+        viewModel.workouts = [currentMonthWorkouts, previousMonthWorkouts]
+        viewModel.workoutShoeNames = PreviewWorkoutMockData.workoutShoeNames
+        viewModel.viewStatus = .none
+        return viewModel
+    }
+    
+    /// 운동 상세 Preview용 ViewModel을 샘플 상세 데이터 UseCase와 함께 생성합니다.
+    func makeWorkoutDetailViewModel(workout: Workout) -> WorkoutDetailViewModel {
+        WorkoutDetailViewModel(
+            useCase: PreviewWorkoutDetailUseCase(),
+            workout: workout
+        )
+    }
+    
+    /// 신발 선택 Sheet Preview용 ViewModel을 샘플 신발 목록이 채워진 상태로 생성합니다.
+    func makeChooseShoesViewModel(workouts: [Workout]) -> ChooseShoesViewModel {
+        let viewModel = ChooseShoesViewModel(
+            useCase: PreviewChooseShoesUseCase(),
+            workouts: workouts
+        )
+        viewModel.shoes = PreviewShoesMockData.shoes
+        viewModel.selectedShoe = PreviewShoesMockData.shoes.first
+        return viewModel
+    }
+    
+    /// 자동 마일리지 등록 Preview용 ViewModel을 샘플 신발 목록이 채워진 상태로 생성합니다.
+    func makeAutoMileageShoesViewModel() -> AutoMileageShoesViewModel {
+        let viewModel = AutoMileageShoesViewModel(useCase: PreviewAddMileageShoesUseCase())
+        viewModel.shoes = PreviewShoesMockData.shoes
+        viewModel.selectedShoesId = PreviewShoesMockData.shoes.first?.id
+        return viewModel
+    }
+    
+    /// 마이페이지 Preview용 ViewModel을 생성합니다.
+    func makeMyPageViewModel() -> MyPageViewModel {
+        MyPageViewModel(useCase: PreviewMyPageUseCase())
+    }
+    
+    /// 명예의 전당 Preview용 ViewModel을 졸업 신발 샘플 데이터가 채워진 상태로 생성합니다.
+    func makeHOFViewModel() -> HOFViewModel {
+        let viewModel = HOFViewModel(useCase: PreviewHOFUseCase())
+        viewModel.shoes = PreviewShoesMockData.hallOfFameShoes
+        return viewModel
+    }
+    
+    /// 개발자 정보 Preview용 ViewModel을 생성합니다.
+    func makeInformationViewModel() -> InformationViewModel {
+        InformationViewModel()
+    }
+}
+#endif

--- a/Run Mile/App/Core/Preview/PreviewMyPageUseCases.swift
+++ b/Run Mile/App/Core/Preview/PreviewMyPageUseCases.swift
@@ -1,0 +1,26 @@
+//
+//  PreviewMyPageUseCases.swift
+//  Run Mile
+//
+//  Created by Codex on 5/8/26.
+//
+
+#if DEBUG
+import Foundation
+
+
+struct PreviewMyPageUseCase: MyPageUseCase {
+    /// Preview에서는 메일 작성 가능 상태로 고정해 문의 화면 노출을 확인할 수 있게 합니다.
+    func evaluateMailAvailable() -> Bool {
+        true
+    }
+}
+
+
+struct PreviewHOFUseCase: HOFUseCase {
+    /// 명예의 전당 Preview에 사용할 졸업 신발 목록을 반환합니다.
+    func fetchShoes() async throws -> [Shoes] {
+        PreviewShoesMockData.hallOfFameShoes
+    }
+}
+#endif

--- a/Run Mile/App/Core/Preview/PreviewShoesMockData.swift
+++ b/Run Mile/App/Core/Preview/PreviewShoesMockData.swift
@@ -1,0 +1,116 @@
+//
+//  PreviewShoesMockData.swift
+//  Run Mile
+//
+//  Created by Codex on 5/8/26.
+//
+
+#if DEBUG
+import Foundation
+import HealthKit
+
+
+enum PreviewShoesMockData {
+    static let monthlyRunningDistance: Double = 128.4
+    static let workouts: [Workout] = [
+        makeWorkout(daysAgo: 1, distance: 10240, duration: 3100, calories: 612),
+        makeWorkout(daysAgo: 4, distance: 8200, duration: 2520, calories: 486),
+        makeWorkout(daysAgo: 8, distance: 12500, duration: 3920, calories: 721),
+        makeWorkout(daysAgo: 34, distance: 6200, duration: 2280, calories: 356),
+        makeWorkout(daysAgo: 39, distance: 7400, duration: 2700, calories: 421)
+    ]
+    
+    static let shoes: [Shoes] = [
+        Shoes(
+            id: UUID(uuidString: "3D87E0D2-44D3-4C7E-B84D-6A7F9A4C74D1") ?? UUID(),
+            image: placeholderImageData,
+            shoesName: "Nike Alphafly 3",
+            nickname: "레이스 데이",
+            goalMileage: 800,
+            currentMileage: 84,
+            workouts: Array(workouts.prefix(3))
+        ),
+        Shoes(
+            id: UUID(uuidString: "5D241D30-AE71-4FC2-A9D8-22B6C647E0BD") ?? UUID(),
+            image: placeholderImageData,
+            shoesName: "Asics Novablast 4",
+            nickname: "데일리 조깅",
+            goalMileage: 700,
+            currentMileage: 212,
+            workouts: Array(workouts.suffix(2))
+        ),
+        Shoes(
+            id: UUID(uuidString: "4B42030B-B259-4185-9D73-24472921C588") ?? UUID(),
+            image: placeholderImageData,
+            shoesName: "Hoka Clifton 9",
+            nickname: "회복런",
+            goalMileage: 650,
+            currentMileage: 552,
+            workouts: [
+                makeWorkout(daysAgo: 3, distance: 5100, duration: 2070, calories: 286)
+            ]
+        )
+    ]
+    
+    static let hallOfFameShoes: [Shoes] = [
+        Shoes(
+            id: UUID(uuidString: "86E0947D-D1CC-438E-9BB2-FBE27540E422") ?? UUID(),
+            image: placeholderImageData,
+            shoesName: "Adidas Adizero Adios Pro 3",
+            nickname: "첫 풀코스",
+            goalMileage: 600,
+            currentMileage: 624,
+            workouts: Array(workouts.prefix(2)),
+            isGraduate: true
+        ),
+        Shoes(
+            id: UUID(uuidString: "E947029C-C831-4DE8-9444-925C1B2F3D5F") ?? UUID(),
+            image: placeholderImageData,
+            shoesName: "New Balance 1080v13",
+            nickname: "겨울 훈련화",
+            goalMileage: 700,
+            currentMileage: 732,
+            workouts: Array(workouts.suffix(2)),
+            isGraduate: true
+        )
+    ]
+    
+    static var primaryShoes: Shoes {
+        shoes[0]
+    }
+    
+    static var primaryWorkout: Workout {
+        workouts[0]
+    }
+    
+    private static let placeholderImageData = Data()
+    
+    /// 신발 Preview에서 사용하는 가벼운 HKWorkout 샘플을 생성합니다.
+    private static func makeWorkout(
+        daysAgo: Int,
+        distance: Double,
+        duration: TimeInterval,
+        calories: Double
+    ) -> Workout {
+        let endDate = referenceDate.addingTimeInterval(-Double(daysAgo) * 24 * 60 * 60)
+        let startDate = endDate.addingTimeInterval(-duration)
+        let workout = HKWorkout(
+            activityType: .running,
+            start: startDate,
+            end: endDate,
+            duration: duration,
+            totalEnergyBurned: HKQuantity(unit: .kilocalorie(), doubleValue: calories),
+            totalDistance: HKQuantity(unit: .meter(), doubleValue: distance),
+            metadata: nil
+        )
+        
+        return Workout(workout: workout)
+    }
+    
+    private static let referenceDate: Date = {
+        Calendar.current.date(
+            from: DateComponents(year: 2026, month: 5, day: 8, hour: 7, minute: 30)
+        ) ?? Date()
+    }()
+}
+#endif

--- a/Run Mile/App/Core/Preview/PreviewShoesUseCases.swift
+++ b/Run Mile/App/Core/Preview/PreviewShoesUseCases.swift
@@ -1,0 +1,51 @@
+//
+//  PreviewShoesUseCases.swift
+//  Run Mile
+//
+//  Created by Codex on 5/8/26.
+//
+
+#if DEBUG
+import Foundation
+import PhotosUI
+import SwiftUI
+
+
+struct PreviewShoesListUseCase: ShoesListUseCase {
+    let shoes: [Shoes]
+    let monthlyDistance: Double
+    
+    /// 신발 목록 Preview에 사용할 샘플 신발 데이터를 반환합니다.
+    func fetchShoes() async throws -> [Shoes] {
+        shoes
+    }
+    
+    /// 신발 목록 Preview에 사용할 이번 달 전체 러닝 거리를 반환합니다.
+    func fetchMonthlyRunningDistance() async throws -> Double {
+        monthlyDistance
+    }
+}
+
+
+struct PreviewShoesDetailUseCase: ShoesDetailUseCase {
+    /// Preview에서는 저장소를 변경하지 않고 편집 완료 흐름만 통과시킵니다.
+    func editShoes(shoes: Shoes) async throws {}
+    
+    /// Preview에서는 저장소를 변경하지 않고 삭제 완료 흐름만 통과시킵니다.
+    func deleteShoes(shoes: Shoes) async throws {}
+    
+    /// Preview에서는 저장소를 변경하지 않고 명예의 전당 등록 흐름만 통과시킵니다.
+    func graduateShoes(shoes: Shoes) async throws {}
+}
+
+
+struct PreviewAddShoesUseCase: AddShoesUseCase {
+    /// Preview에서는 선택된 사진 데이터를 그대로 빈 이미지 데이터로 대체합니다.
+    func photoToData(photo: PhotosPickerItem) async throws -> Data {
+        Data()
+    }
+    
+    /// Preview에서는 저장소를 변경하지 않고 저장 완료 흐름만 통과시킵니다.
+    func saveShoes(shoes: Shoes) async throws {}
+}
+#endif

--- a/Run Mile/App/Core/Preview/PreviewWorkoutMockData.swift
+++ b/Run Mile/App/Core/Preview/PreviewWorkoutMockData.swift
@@ -1,0 +1,124 @@
+//
+//  PreviewWorkoutMockData.swift
+//  Run Mile
+//
+//  Created by Codex on 5/8/26.
+//
+
+#if DEBUG
+import CoreLocation
+import Foundation
+
+
+enum PreviewWorkoutMockData {
+    static let detail: WorkoutDetailData = {
+        let workout = PreviewShoesMockData.primaryWorkout
+        let startDate = workout.workout.startDate
+        let duration = Int(workout.time)
+        let step = 180
+        let samples = stride(from: 0, through: duration, by: step).map { seconds in
+            makeSample(seconds: seconds, startDate: startDate)
+        }
+        let routes = makeRoutes(startDate: startDate, duration: duration, step: 60)
+        
+        var detail = WorkoutDetailData()
+        detail.heartRate = samples.map {
+            UnifiedWorkoutDetailData(seconds: $0.seconds, date: $0.date, value: $0.heartRate)
+        }
+        detail.runningPace = samples.map {
+            UnifiedWorkoutDetailData(seconds: $0.seconds, date: $0.date, value: $0.speed)
+        }
+        detail.power = samples.map {
+            UnifiedWorkoutDetailData(seconds: $0.seconds, date: $0.date, value: $0.power)
+        }
+        detail.verticalOscillation = samples.map {
+            UnifiedWorkoutDetailData(seconds: $0.seconds, date: $0.date, value: $0.verticalOscillation)
+        }
+        detail.groundContactTime = samples.map {
+            UnifiedWorkoutDetailData(seconds: $0.seconds, date: $0.date, value: $0.groundContactTime)
+        }
+        detail.strideLength = samples.map {
+            UnifiedWorkoutDetailData(seconds: $0.seconds, date: $0.date, value: $0.strideLength)
+        }
+        detail.splits = makeSplits()
+        detail.cadence = 174
+        detail.routes = routes
+        detail.routeSegments = makeRouteSegments(routes: routes)
+        return detail
+    }()
+    
+    /// 운동 목록 Preview에서 운동별 등록 신발명을 표시하기 위한 샘플 매핑입니다.
+    static let workoutShoeNames: [UUID: String] = [
+        PreviewShoesMockData.workouts[0].id: PreviewShoesMockData.shoes[0].shoesName,
+        PreviewShoesMockData.workouts[1].id: PreviewShoesMockData.shoes[0].shoesName,
+        PreviewShoesMockData.workouts[3].id: PreviewShoesMockData.shoes[1].shoesName
+    ]
+    
+    private static func makeSample(seconds: Int, startDate: Date) -> WorkoutMetricSample {
+        let progress = Double(seconds) / 3100
+        let wave = sin(progress * .pi * 5)
+        
+        return WorkoutMetricSample(
+            seconds: seconds,
+            date: startDate.addingTimeInterval(TimeInterval(seconds)),
+            heartRate: 136 + progress * 38 + wave * 5,
+            speed: 2.72 + progress * 0.58 + wave * 0.16,
+            power: 218 + progress * 54 + wave * 12,
+            verticalOscillation: 7.8 + wave * 0.45,
+            groundContactTime: 245 - progress * 24 + wave * 5,
+            strideLength: 1.05 + progress * 0.18 + wave * 0.04
+        )
+    }
+    
+    private static func makeRoutes(startDate: Date, duration: Int, step: Int) -> [CLLocation] {
+        stride(from: 0, through: duration, by: step).map { seconds in
+            let index = Double(seconds / step)
+            let latitude = 37.5268 + index * 0.00018
+            let longitude = 126.9250 + sin(index / 5) * 0.0014
+            let altitude = 28 + sin(index / 4) * 11 + index * 0.12
+            
+            return CLLocation(
+                coordinate: CLLocationCoordinate2D(latitude: latitude, longitude: longitude),
+                altitude: altitude,
+                horizontalAccuracy: 6,
+                verticalAccuracy: 5,
+                timestamp: startDate.addingTimeInterval(TimeInterval(seconds))
+            )
+        }
+    }
+    
+    private static func makeRouteSegments(routes: [CLLocation]) -> [WorkoutRouteSegment] {
+        zip(routes, routes.dropFirst()).enumerated().map { index, pair in
+            let ratio = Double(index) / Double(max(routes.count - 2, 1))
+            return WorkoutRouteSegment(
+                coordinates: [pair.0.coordinate, pair.1.coordinate],
+                averageSpeed: 2.8 + ratio * 0.55,
+                paceRatio: ratio
+            )
+        }
+    }
+    
+    private static func makeSplits() -> [SplitInfo] {
+        [
+            SplitInfo(label: "1 km", duration: 322, pace: "5'22\""),
+            SplitInfo(label: "2 km", duration: 315, pace: "5'15\""),
+            SplitInfo(label: "3 km", duration: 306, pace: "5'06\""),
+            SplitInfo(label: "4 km", duration: 298, pace: "4'58\""),
+            SplitInfo(label: "5 km", duration: 304, pace: "5'04\""),
+            SplitInfo(label: "6 km", duration: 292, pace: "4'52\"")
+        ]
+    }
+}
+
+
+private struct WorkoutMetricSample {
+    let seconds: Int
+    let date: Date
+    let heartRate: Double
+    let speed: Double
+    let power: Double
+    let verticalOscillation: Double
+    let groundContactTime: Double
+    let strideLength: Double
+}
+#endif

--- a/Run Mile/App/Core/Preview/PreviewWorkoutUseCases.swift
+++ b/Run Mile/App/Core/Preview/PreviewWorkoutUseCases.swift
@@ -1,0 +1,95 @@
+//
+//  PreviewWorkoutUseCases.swift
+//  Run Mile
+//
+//  Created by Codex on 5/8/26.
+//
+
+#if DEBUG
+import CoreLocation
+import Foundation
+
+
+struct PreviewHealthDataUseCase: HealthDataUseCase {
+    /// Preview에서는 HealthKit 권한 요청 없이 바로 데이터를 표시합니다.
+    func checkHealthAuthorization() async throws -> Bool {
+        false
+    }
+    
+    /// 운동 목록 Preview에 사용할 샘플 운동 데이터를 반환합니다.
+    func fetchWorkoutData() async throws -> [Workout] {
+        PreviewShoesMockData.workouts
+    }
+    
+    /// 운동 목록 Preview에 사용할 운동-신발 등록 정보를 반환합니다.
+    func fetchWorkoutShoeNames() async throws -> [UUID: String] {
+        PreviewWorkoutMockData.workoutShoeNames
+    }
+}
+
+
+struct PreviewWorkoutDetailUseCase: WorkoutDetailUseCase {
+    /// 운동 상세 Preview에 사용할 차트, 구간, 경로 데이터를 반환합니다.
+    func fetchWorkoutDetailData(
+        workout: Workout,
+        samplingCount: Int
+    ) async throws -> WorkoutDetailData {
+        PreviewWorkoutMockData.detail
+    }
+    
+    /// Preview 데이터는 이미 표시용으로 적당히 줄어든 상태라 원본을 반환합니다.
+    func downsampling(
+        samples: [UnifiedWorkoutDetailData],
+        targetCount: Int
+    ) -> [UnifiedWorkoutDetailData] {
+        samples
+    }
+    
+    /// Preview 지도에 사용할 페이스 구간을 위치 배열 기반으로 간단히 생성합니다.
+    func buildRouteSegments(
+        locations: [CLLocation],
+        runningPace: [UnifiedWorkoutDetailData],
+        workoutStartDate: Date
+    ) -> [WorkoutRouteSegment] {
+        guard locations.count >= 2 else { return [] }
+        
+        return zip(locations, locations.dropFirst()).enumerated().map { index, pair in
+            let ratio = Double(index) / Double(max(locations.count - 2, 1))
+            return WorkoutRouteSegment(
+                coordinates: [pair.0.coordinate, pair.1.coordinate],
+                averageSpeed: 2.8 + ratio * 0.55,
+                paceRatio: ratio
+            )
+        }
+    }
+}
+
+
+struct PreviewChooseShoesUseCase: ChooseShoesUseCase {
+    /// 신발 선택 Preview에 사용할 샘플 신발 목록을 반환합니다.
+    func fetchShoesList() async throws -> [Shoes] {
+        PreviewShoesMockData.shoes
+    }
+    
+    /// Preview에서는 저장소를 변경하지 않고 등록 완료 흐름만 통과시킵니다.
+    func registerWorkouts(shoes: Shoes, workouts: [Workout]) async throws {}
+}
+
+
+struct PreviewAddMileageShoesUseCase: AddMileageShoesUseCase {
+    private let selectedShoesId: UUID? = PreviewShoesMockData.shoes.first?.id
+    
+    /// 자동 등록 Preview에 사용할 샘플 신발 목록을 반환합니다.
+    func fetchAllShoes() async throws -> [Shoes] {
+        PreviewShoesMockData.shoes
+    }
+    
+    /// 자동 등록 Preview에서 선택된 신발 ID를 반환합니다.
+    func fetchCurrentSelectedSheos() -> UUID? {
+        selectedShoesId
+    }
+    
+    /// Preview에서는 UserDefaults를 변경하지 않습니다.
+    func setCurrentSelectedShoes(id: UUID?) {}
+}
+#endif

--- a/Run Mile/App/Core/ScreenDependencyProviding.swift
+++ b/Run Mile/App/Core/ScreenDependencyProviding.swift
@@ -1,0 +1,22 @@
+//
+//  ScreenDependencyProviding.swift
+//  Run Mile
+//
+//  Created by 테스트 on 5/8/26.
+//
+
+import Foundation
+
+
+protocol ScreenDependencyProviding {
+    func makeShoesListViewModel() -> ShoesListViewModel
+    func makeShoesDetailViewModel(shoes: Shoes) -> ShoesDetailViewModel
+    func makeAddShoesViewModel() -> AddShoesViewModel
+    func makeWorkoutListViewModel() -> WorkoutListViewModel
+    func makeWorkoutDetailViewModel(workout: Workout) -> WorkoutDetailViewModel
+    func makeChooseShoesViewModel(workouts: [Workout]) -> ChooseShoesViewModel
+    func makeAutoMileageShoesViewModel() -> AutoMileageShoesViewModel
+    func makeMyPageViewModel() -> MyPageViewModel
+    func makeHOFViewModel() -> HOFViewModel
+    func makeInformationViewModel() -> InformationViewModel
+}

--- a/Run Mile/App/Core/ScreenFactory.swift
+++ b/Run Mile/App/Core/ScreenFactory.swift
@@ -1,0 +1,73 @@
+//
+//  ScreenFactory.swift
+//  Run Mile
+//
+//  Created by Codex on 5/8/26.
+//
+
+import SwiftUI
+
+
+struct ScreenFactory {
+    private let container: ScreenDependencyProviding
+    
+    init(container: ScreenDependencyProviding) {
+        self.container = container
+    }
+    
+    /// NavigationCoordinator의 화면 상태를 실제 SwiftUI 화면으로 변환합니다.
+    @ViewBuilder
+    func makeView(for screen: NavigationCoordinator.Screen) -> some View {
+        switch screen {
+        case .shoes:
+            ShoesListView(viewModel: container.makeShoesListViewModel())
+        case let .shoesDetail(shoes):
+            ShoesDetailView(viewModel: container.makeShoesDetailViewModel(shoes: shoes))
+            
+        case .workout:
+            WorkoutListView(viewModel: container.makeWorkoutListViewModel())
+        case let .workoutDetail(workout):
+            WorkoutDetailView(viewModel: container.makeWorkoutDetailViewModel(workout: workout))
+            
+        case .myPage:
+            MyPageView(viewModel: container.makeMyPageViewModel())
+        case .fitnessConnect:
+            FitnessConnectView()
+        case .hof:
+            HOFView(viewModel: container.makeHOFViewModel())
+        case .info:
+            InformationView(viewModel: container.makeInformationViewModel())
+        case let .imageDetail(image):
+            if #available(iOS 18.0, *) {
+                ImageDetailView(image: image)
+                    .toolbarVisibility(.hidden, for: .tabBar)
+            } else {
+                ImageDetailView(image: image)
+                    .toolbar(.hidden, for: .tabBar)
+            }
+        }
+    }
+    
+    /// NavigationCoordinator의 Sheet 상태를 실제 SwiftUI sheet 화면으로 변환합니다.
+    @ViewBuilder
+    func makeSheet(for sheet: NavigationCoordinator.Sheet) -> some View {
+        switch sheet {
+        case let .addShoes(action):
+            AddShoesView(
+                viewModel: container.makeAddShoesViewModel(),
+                dismissAction: action
+            )
+        case let .chooseShoes(workouts, action):
+            ChooseShoesView(
+                viewModel: container.makeChooseShoesViewModel(workouts: workouts),
+                dismiss: action
+            )
+            .presentationDetents([.medium, .large])
+            .presentationDragIndicator(.hidden)
+        case .automaticRegister:
+            AutoMileageShoesView(viewModel: container.makeAutoMileageShoesViewModel())
+                .presentationDetents([.medium, .large])
+                .presentationDragIndicator(.hidden)
+        }
+    }
+}

--- a/Run Mile/Presentation/0.Main/MainTabView.swift
+++ b/Run Mile/Presentation/0.Main/MainTabView.swift
@@ -10,16 +10,16 @@ import SwiftUI
 
 struct MainTabView: View {
     @State private var navigationCoordinator: NavigationCoordinator = .shared
-    @State private var viewModel: MainTabViewModel = .init()
+    private let screenFactory: ScreenFactory = .init(container: AppDIContainer())
     
     var body: some View {
         TabView(selection: $navigationCoordinator.tabStatus) {
             NavigationStack(path: $navigationCoordinator.shoesPath) {
-                navigationCoordinator.build(.shoes)
+                screenFactory.makeView(for: .shoes)
                     .navigationDestination(
                         for: NavigationCoordinator.Screen.self,
                         destination: {
-                            navigationCoordinator.build($0)
+                            screenFactory.makeView(for: $0)
                         }
                     )
             }
@@ -30,11 +30,11 @@ struct MainTabView: View {
             }
             
             NavigationStack(path: $navigationCoordinator.workoutPath) {
-                navigationCoordinator.build(.workout)
+                screenFactory.makeView(for: .workout)
                     .navigationDestination(
                         for: NavigationCoordinator.Screen.self,
                         destination: {
-                            navigationCoordinator.build($0)
+                            screenFactory.makeView(for: $0)
                         }
                     )
             }
@@ -45,11 +45,11 @@ struct MainTabView: View {
             }
             
             NavigationStack(path: $navigationCoordinator.myPagePath) {
-                navigationCoordinator.build(.myPage)
+                screenFactory.makeView(for: .myPage)
                     .navigationDestination(
                         for: NavigationCoordinator.Screen.self,
                         destination: {
-                            navigationCoordinator.build($0)
+                            screenFactory.makeView(for: $0)
                         }
                     )
             }
@@ -60,7 +60,7 @@ struct MainTabView: View {
             }
         }
         .sheet(item: $navigationCoordinator.sheet) {
-            navigationCoordinator.build($0)
+            screenFactory.makeSheet(for: $0)
         }
         .alert(
             navigationCoordinator.alert?.title ?? "알 수 없음",
@@ -91,5 +91,4 @@ struct MainTabView: View {
         }
     }
 }
-
 

--- a/Run Mile/Presentation/0.Main/NavigationCoordinator.swift
+++ b/Run Mile/Presentation/0.Main/NavigationCoordinator.swift
@@ -80,61 +80,6 @@ extension NavigationCoordinator {
     public func dismissSheet() {
         self.sheet = nil
     }
-    
-    @ViewBuilder
-    public func build(_ screen: Screen) -> some View {
-        switch screen {
-        case .shoes:
-            ShoesListView()
-        case let .shoesDetail(shoes):
-            ShoesDetailView(shoes: shoes)
-            
-        case .workout:
-            WorkoutListView()
-        case let .workoutDetail(workout):
-            WorkoutDetailView(
-                viewModel: .init(
-                    useCase: DefaultWorkoutDetailUseCase(
-                        workoutRepository: WorkoutDataRepositoryImpl()
-                    ),
-                    workout: workout
-                )
-            )
-            
-        case .myPage:
-            MyPageView()
-        case .fitnessConnect:
-            FitnessConnectView()
-        case .hof:
-            HOFView()
-        case .info:
-            InformationView()
-        case let .imageDetail(image):
-            if #available(iOS 18.0, *) {
-                ImageDetailView(image: image)
-                    .toolbarVisibility(.hidden, for: .tabBar)
-            } else {
-                ImageDetailView(image: image)
-                    .toolbar(.hidden, for: .tabBar)
-            }
-        }
-    }
-    
-    @ViewBuilder
-    public func build(_ sheet: Sheet) -> some View {
-        switch sheet {
-        case let .addShoes(action):
-            AddShoesView(dismissAction: action)
-        case let .chooseShoes(workouts, action):
-            ChooseShoesView(workouts: workouts, dismiss: action)
-                .presentationDetents([.medium, .large])
-                .presentationDragIndicator(.hidden)
-        case .automaticRegister:
-            AutoMileageShoesView()
-                .presentationDetents([.medium, .large])
-                .presentationDragIndicator(.hidden)
-        }
-    }
 }
 
 
@@ -177,8 +122,8 @@ extension NavigationCoordinator {
 extension NavigationCoordinator.TabStatus: Hashable {}
 extension NavigationCoordinator.Screen: Hashable {}
 extension NavigationCoordinator.Sheet: Hashable, Identifiable {
-    static func == (rhs: Self, lhs: Self) -> Bool {
-        switch (rhs, lhs) {
+    static func == (lhs: Self, rhs: Self) -> Bool {
+        switch (lhs, rhs) {
         case (.addShoes, .addShoes):
             return true
         case let (.chooseShoes(first, _), .chooseShoes(second, _)):
@@ -191,6 +136,14 @@ extension NavigationCoordinator.Sheet: Hashable, Identifiable {
     }
     
     func hash(into hasher: inout Hasher) {
-        hasher.combine(self)
+        switch self {
+        case .addShoes:
+            hasher.combine("addShoes")
+        case let .chooseShoes(workouts, _):
+            hasher.combine("chooseShoes")
+            hasher.combine(workouts)
+        case .automaticRegister:
+            hasher.combine("automaticRegister")
+        }
     }
 }

--- a/Run Mile/Presentation/1.Shoes/1-1.AddShoes/AddShoesView.swift
+++ b/Run Mile/Presentation/1.Shoes/1-1.AddShoes/AddShoesView.swift
@@ -334,7 +334,7 @@ private struct AddShoesTextField: View {
 
 #Preview {
     AddShoesView(
-        viewModel: AppDIContainer().makeAddShoesViewModel(),
+        viewModel: PreviewDIContainer().makeAddShoesViewModel(),
         dismissAction: {}
     )
 }

--- a/Run Mile/Presentation/1.Shoes/1-1.AddShoes/AddShoesView.swift
+++ b/Run Mile/Presentation/1.Shoes/1-1.AddShoes/AddShoesView.swift
@@ -10,15 +10,19 @@ import PhotosUI
 
 
 struct AddShoesView: View {
-    @State private var viewModel: AddShoesViewModel = .init(
-        useCase: DefaultAddShoesUseCase(
-            repository: ShoesDataRepositoryImpl()
-        )
-    )
+    @State private var viewModel: AddShoesViewModel
     
     @FocusState private var focusedField: AddShoesViewModel.TextFieldCategory?
     
     let dismissAction: () -> Void
+    
+    init(
+        viewModel: AddShoesViewModel,
+        dismissAction: @escaping () -> Void
+    ) {
+        self.viewModel = viewModel
+        self.dismissAction = dismissAction
+    }
     
     var body: some View {
         NavigationStack {
@@ -329,5 +333,8 @@ private struct AddShoesTextField: View {
 }
 
 #Preview {
-    AddShoesView {}
+    AddShoesView(
+        viewModel: AppDIContainer().makeAddShoesViewModel(),
+        dismissAction: {}
+    )
 }

--- a/Run Mile/Presentation/1.Shoes/1-2.ShoesDetail/ShoesDetailView.swift
+++ b/Run Mile/Presentation/1.Shoes/1-2.ShoesDetail/ShoesDetailView.swift
@@ -11,13 +11,8 @@ import SwiftUI
 struct ShoesDetailView: View {
     @State private var viewModel: ShoesDetailViewModel
     
-    init(shoes: Shoes) {
-        self.viewModel = .init(
-            useCase: DefaultShoesDetailUseCase(
-                repository: ShoesDataRepositoryImpl()
-            ),
-            shoes: shoes
-        )
+    init(viewModel: ShoesDetailViewModel) {
+        self.viewModel = viewModel
     }
     
     var body: some View {

--- a/Run Mile/Presentation/1.Shoes/1-2.ShoesDetail/ShoesDetailView.swift
+++ b/Run Mile/Presentation/1.Shoes/1-2.ShoesDetail/ShoesDetailView.swift
@@ -256,3 +256,13 @@ struct ShoesDetailView: View {
         }
     }
 }
+
+#Preview {
+    NavigationStack {
+        ShoesDetailView(
+            viewModel: PreviewDIContainer().makeShoesDetailViewModel(
+                shoes: PreviewShoesMockData.primaryShoes
+            )
+        )
+    }
+}

--- a/Run Mile/Presentation/1.Shoes/ShoesListView.swift
+++ b/Run Mile/Presentation/1.Shoes/ShoesListView.swift
@@ -101,5 +101,5 @@ struct ShoesListView: View {
 }
 
 #Preview {
-    ShoesListView(viewModel: AppDIContainer().makeShoesListViewModel())
+    ShoesListView(viewModel: PreviewDIContainer().makeShoesListViewModel())
 }

--- a/Run Mile/Presentation/1.Shoes/ShoesListView.swift
+++ b/Run Mile/Presentation/1.Shoes/ShoesListView.swift
@@ -8,12 +8,11 @@
 import SwiftUI
 
 struct ShoesListView: View {
-    @State private var viewModel: ShoesListViewModel = .init(
-        useCase: DefaultShoesViewUseCase(
-            repository: ShoesDataRepositoryImpl(),
-            workoutRepository: WorkoutDataRepositoryImpl()
-        )
-    )
+    @State private var viewModel: ShoesListViewModel
+    
+    init(viewModel: ShoesListViewModel) {
+        self.viewModel = viewModel
+    }
     
     var body: some View {
         NavigationStack {
@@ -102,5 +101,5 @@ struct ShoesListView: View {
 }
 
 #Preview {
-    ShoesListView()
+    ShoesListView(viewModel: AppDIContainer().makeShoesListViewModel())
 }

--- a/Run Mile/Presentation/2.Workout/2-1.ChooseShoes/ChooseShoesView.swift
+++ b/Run Mile/Presentation/2.Workout/2-1.ChooseShoes/ChooseShoesView.swift
@@ -14,15 +14,10 @@ struct ChooseShoesView: View {
     let dismiss: () -> Void
     
     init(
-        workouts: [Workout],
+        viewModel: ChooseShoesViewModel,
         dismiss: @escaping () -> Void
     ) {
-        self.viewModel = .init(
-            useCase: DefaultChooseShoesUseCase(
-                repository: ShoesDataRepositoryImpl()
-            ),
-            workouts: workouts
-        )
+        self.viewModel = viewModel
         self.dismiss = dismiss
     }
     

--- a/Run Mile/Presentation/2.Workout/2-1.ChooseShoes/ChooseShoesView.swift
+++ b/Run Mile/Presentation/2.Workout/2-1.ChooseShoes/ChooseShoesView.swift
@@ -85,6 +85,15 @@ struct ChooseShoesView: View {
     }
 }
 
+#Preview {
+    ChooseShoesView(
+        viewModel: PreviewDIContainer().makeChooseShoesViewModel(
+            workouts: Array(PreviewShoesMockData.workouts.prefix(2))
+        ),
+        dismiss: {}
+    )
+}
+
 
 private struct ChooseShoesCell: View {
     let shoe: Shoes

--- a/Run Mile/Presentation/2.Workout/2-2.AutoMileage/AutoMileageShoesView.swift
+++ b/Run Mile/Presentation/2.Workout/2-2.AutoMileage/AutoMileageShoesView.swift
@@ -99,6 +99,12 @@ struct AutoMileageShoesView: View {
     }
 }
 
+#Preview {
+    AutoMileageShoesView(
+        viewModel: PreviewDIContainer().makeAutoMileageShoesViewModel()
+    )
+}
+
 
 private struct ChooseShoesCell: View {
     let shoe: Shoes

--- a/Run Mile/Presentation/2.Workout/2-2.AutoMileage/AutoMileageShoesView.swift
+++ b/Run Mile/Presentation/2.Workout/2-2.AutoMileage/AutoMileageShoesView.swift
@@ -9,11 +9,11 @@ import SwiftUI
 
 
 struct AutoMileageShoesView: View {
-    @State private var viewModel: AutoMileageShoesViewModel = .init(
-        useCase: DefaultAddMileageShoesUseCase(
-            shoesRepository: ShoesDataRepositoryImpl()
-        )
-    )
+    @State private var viewModel: AutoMileageShoesViewModel
+    
+    init(viewModel: AutoMileageShoesViewModel) {
+        self.viewModel = viewModel
+    }
     
     var body: some View {
         VStack(spacing: 0) {

--- a/Run Mile/Presentation/2.Workout/2-3.WorkoutDetail/WorkoutDetailView.swift
+++ b/Run Mile/Presentation/2.Workout/2-3.WorkoutDetail/WorkoutDetailView.swift
@@ -56,3 +56,13 @@ struct WorkoutDetailView: View {
         .toolbar(viewModel.showFullMap ? .hidden : .visible, for: .tabBar)
     }
 }
+
+#Preview {
+    NavigationStack {
+        WorkoutDetailView(
+            viewModel: PreviewDIContainer().makeWorkoutDetailViewModel(
+                workout: PreviewShoesMockData.primaryWorkout
+            )
+        )
+    }
+}

--- a/Run Mile/Presentation/2.Workout/WorkoutListView.swift
+++ b/Run Mile/Presentation/2.Workout/WorkoutListView.swift
@@ -9,12 +9,11 @@ import SwiftUI
 
 
 struct WorkoutListView: View {
-    @State private var viewModel: WorkoutListViewModel = .init(
-        useCase: DefaultHealthDataUseCase(
-            workoutDataRepository: WorkoutDataRepositoryImpl(),
-            shoesDataRepository: ShoesDataRepositoryImpl()
-        )
-    )
+    @State private var viewModel: WorkoutListViewModel
+    
+    init(viewModel: WorkoutListViewModel) {
+        self.viewModel = viewModel
+    }
 
     var body: some View {
         ZStack {
@@ -223,6 +222,6 @@ struct WorkoutListView: View {
 
 #Preview {
     NavigationStack {
-        WorkoutListView()
+        WorkoutListView(viewModel: AppDIContainer().makeWorkoutListViewModel())
     }
 }

--- a/Run Mile/Presentation/2.Workout/WorkoutListView.swift
+++ b/Run Mile/Presentation/2.Workout/WorkoutListView.swift
@@ -222,6 +222,6 @@ struct WorkoutListView: View {
 
 #Preview {
     NavigationStack {
-        WorkoutListView(viewModel: AppDIContainer().makeWorkoutListViewModel())
+        WorkoutListView(viewModel: PreviewDIContainer().makeWorkoutListViewModel())
     }
 }

--- a/Run Mile/Presentation/3.MyPage/3-1.HallOfFame/HOFView.swift
+++ b/Run Mile/Presentation/3.MyPage/3-1.HallOfFame/HOFView.swift
@@ -199,6 +199,8 @@ struct HOFShoesCard: View {
 }
 
 
-#Preview("Empty") {
-    HOFView(viewModel: AppDIContainer().makeHOFViewModel())
+#Preview("Hall of Fame") {
+    NavigationStack {
+        HOFView(viewModel: PreviewDIContainer().makeHOFViewModel())
+    }
 }

--- a/Run Mile/Presentation/3.MyPage/3-1.HallOfFame/HOFView.swift
+++ b/Run Mile/Presentation/3.MyPage/3-1.HallOfFame/HOFView.swift
@@ -8,12 +8,11 @@
 import SwiftUI
 
 struct HOFView: View {
-    @State private var viewModel: HOFViewModel = .init(
-        useCase: DefaultHOFUseCase(
-            repository: ShoesDataRepositoryImpl()
-        )
-    )
+    @State private var viewModel: HOFViewModel
     
+    init(viewModel: HOFViewModel) {
+        self.viewModel = viewModel
+    }
     
     var body: some View {
         ZStack(alignment: .top) {
@@ -201,5 +200,5 @@ struct HOFShoesCard: View {
 
 
 #Preview("Empty") {
-    HOFView()
+    HOFView(viewModel: AppDIContainer().makeHOFViewModel())
 }

--- a/Run Mile/Presentation/3.MyPage/3-4.Information/InformationView.swift
+++ b/Run Mile/Presentation/3.MyPage/3-4.Information/InformationView.swift
@@ -211,3 +211,9 @@ private enum BrandIcon {
     case github
     case linkedIn
 }
+
+#Preview {
+    NavigationStack {
+        InformationView(viewModel: PreviewDIContainer().makeInformationViewModel())
+    }
+}

--- a/Run Mile/Presentation/3.MyPage/3-4.Information/InformationView.swift
+++ b/Run Mile/Presentation/3.MyPage/3-4.Information/InformationView.swift
@@ -9,7 +9,11 @@ import SwiftUI
 
 
 struct InformationView: View {
-    let viewModel: InformationViewModel = .init()
+    let viewModel: InformationViewModel
+    
+    init(viewModel: InformationViewModel) {
+        self.viewModel = viewModel
+    }
     
     var body: some View {
         ScrollView {

--- a/Run Mile/Presentation/3.MyPage/MyPageView.swift
+++ b/Run Mile/Presentation/3.MyPage/MyPageView.swift
@@ -174,5 +174,5 @@ private struct ScaleButtonStyle: ButtonStyle {
 
 
 #Preview {
-    MyPageView(viewModel: AppDIContainer().makeMyPageViewModel())
+    MyPageView(viewModel: PreviewDIContainer().makeMyPageViewModel())
 }

--- a/Run Mile/Presentation/3.MyPage/MyPageView.swift
+++ b/Run Mile/Presentation/3.MyPage/MyPageView.swift
@@ -9,9 +9,11 @@ import SwiftUI
 
 
 struct MyPageView: View {
-    @State private var viewModel: MyPageViewModel = .init(
-        useCase: DefaultMyPageUseCase()
-    )
+    @State private var viewModel: MyPageViewModel
+    
+    init(viewModel: MyPageViewModel) {
+        self.viewModel = viewModel
+    }
     
     var body: some View {
         ScrollView {
@@ -172,5 +174,5 @@ private struct ScaleButtonStyle: ButtonStyle {
 
 
 #Preview {
-    MyPageView()
+    MyPageView(viewModel: AppDIContainer().makeMyPageViewModel())
 }


### PR DESCRIPTION
close #68

## Summary
이 PR은 앱 전반의 의존성 생성과 화면 생성 책임을 정리하기 위해 `DIContainer`와 `ScreenFactory`를 도입했습니다. 기존에 Coordinator와 각 View에서 직접 구성하던 ViewModel, UseCase, Repository 의존성을 중앙에서 관리하도록 구조를 개선하고, SwiftUI Preview에서 사용할 mock 의존성도 별도로 구성했습니다.

## Key Changes

### 1. App DIContainer 도입
- `AppDIContainer`를 추가해 Repository, UseCase, 화면 생성에 필요한 의존성을 한 곳에서 구성하도록 정리했습니다.
- `ScreenDependencyProviding` 프로토콜을 추가해 화면 생성 계층이 필요한 의존성 계약을 명확히 분리했습니다.
- 앱 런타임에서 사용하는 실제 의존성과 Preview 전용 의존성을 구분할 수 있는 기반을 마련했습니다.

### 2. ScreenFactory 도입
- `ScreenFactory`를 추가해 주요 화면과 ViewModel 생성 책임을 Coordinator에서 분리했습니다.
- `MainTabView`, `NavigationCoordinator`, 신발/운동/마이페이지 관련 화면들이 Factory를 통해 필요한 의존성을 전달받도록 수정했습니다.
- 화면 전환 로직은 유지하면서 객체 생성 책임을 별도 계층으로 옮겨 NavigationCoordinator의 역할을 줄였습니다.

### 3. Preview 전용 Mock 구성
- `PreviewDIContainer`를 추가해 SwiftUI Preview에서 사용할 의존성 구성을 분리했습니다.
- `PreviewShoesUseCases`, `PreviewWorkoutUseCases`, `PreviewMyPageUseCases`를 추가해 Preview 화면에서 실제 데이터 소스 없이 동작할 수 있도록 구성했습니다.
- 신발/운동 mock 데이터를 별도 파일로 분리해 Preview 데이터 재사용성을 높였습니다.

## Impact
- View, ViewModel, UseCase, Repository 간 의존성 생성 흐름이 더 명확해집니다.
- Coordinator가 화면 전환에 더 집중할 수 있고, 화면 생성 책임은 Factory로 분리됩니다.
- Preview와 런타임 의존성을 구분할 수 있어 UI 작업과 테스트 준비가 쉬워집니다.
- 추후 mock 구현체 주입, 테스트 확장, 의존성 교체 작업을 더 안정적으로 진행할 수 있습니다.

## Validation
- 변경 사항은 커밋 기록과 `origin/develop...HEAD` diff 기준으로 확인했습니다.
- 로컬 빌드/테스트는 별도로 실행하지 않았습니다.