### PR TITLE
[Feat] 신발 상세 뷰 관리 기능 추가

### DIFF
--- a/Run Mile/Data/Shoes/ShoesDataRepositoryImpl.swift
+++ b/Run Mile/Data/Shoes/ShoesDataRepositoryImpl.swift
@@ -137,6 +137,10 @@ actor ShoesDataRepositoryImpl: ShoesDataRepository {
             if let entityToDelete = fetchedResult.first {
                 context.delete(entityToDelete)
             }
+            
+            if context.hasChanges {
+                try context.save()
+            }
         }
     }
     

--- a/Run Mile/Presentation/1.Shoes/1-1.AddShoes/AddShoesView.swift
+++ b/Run Mile/Presentation/1.Shoes/1-1.AddShoes/AddShoesView.swift
@@ -118,7 +118,7 @@ struct AddShoesView: View {
                         }
                         
                         // Model Picker
-                        if viewModel.selectedBrand != "기타" {
+                        if viewModel.selectedBrand != ShoeCatalog.other {
                             inputGroup(title: "모델명", icon: "shoe.fill") {
                                 Picker("모델을 선택해주세요", selection: $viewModel.selectedModel) {
                                     ForEach(viewModel.modelList, id: \.self) { model in
@@ -141,12 +141,12 @@ struct AddShoesView: View {
                         }
                         
                         // Manual Input (If 'Etc' selected)
-                        if viewModel.selectedBrand == "기타" || viewModel.selectedModel == "기타" {
+                        if viewModel.selectedBrand == ShoeCatalog.other || viewModel.selectedModel == ShoeCatalog.other {
                             VStack(spacing: 12) {
-                                if viewModel.selectedBrand == "기타" {
+                                if viewModel.selectedBrand == ShoeCatalog.other {
                                     AddShoesTextField(title: "브랜드 직접 입력", text: $viewModel.customBrand, focusState: $focusedField, category: .customBrand)
                                 }
-                                if viewModel.selectedBrand == "기타" || viewModel.selectedModel == "기타" {
+                                if viewModel.selectedBrand == ShoeCatalog.other || viewModel.selectedModel == ShoeCatalog.other {
                                     AddShoesTextField(title: "모델명 직접 입력", text: $viewModel.customModel, focusState: $focusedField, category: .customModel)
                                 }
                             }

--- a/Run Mile/Presentation/1.Shoes/1-1.AddShoes/AddShoesViewModel.swift
+++ b/Run Mile/Presentation/1.Shoes/1-1.AddShoes/AddShoesViewModel.swift
@@ -25,8 +25,13 @@ final class AddShoesViewModel {
     }
     
     // Brand & Model Selection
-    public var selectedBrand: String = "Nike"
-    public var selectedModel: String = "Alphafly 3"
+    public var selectedBrand: String = ShoeCatalog.defaultBrand {
+        didSet {
+            guard oldValue != selectedBrand else { return }
+            selectedModel = ShoeCatalog.defaultModel(for: selectedBrand)
+        }
+    }
+    public var selectedModel: String = ShoeCatalog.defaultModel
     public var customBrand: String = ""
     public var customModel: String = ""
     
@@ -58,39 +63,22 @@ final class AddShoesViewModel {
     
     private var previousImage: Data?
     
-    // MARK: - Constants / Data
-    let brands: [String: [String]] = [
-        "Nike": ["Alphafly 3", "Vaporfly 3", "Pegasus 41", "Invite Run 3", "기타"],
-        "Adidas": ["Adizero Adios Pro 3", "Adizero Takumi Sen 10", "Ultraboost Light", "기타"],
-        "New Balance": ["FuelCell SuperComp Elite v4", "Fresh Foam X 1080v13", "기타"],
-        "Hoka": ["Clifton 9", "Bondi 8", "Mach 6", "Rocket X 2", "기타"],
-        "Saucony": ["Endorphin Pro 4", "Endorphin Speed 4", "Ride 17", "기타"],
-        "Asics": ["Metaspeed Sky Paris", "Metaspeed Edge Paris", "Novablast 4", "Gel-Nimbus 26", "기타"],
-        "Mizuno": ["Wave Rebellion Pro 2", "Wave Rider 27", "기타"],
-        "Brooks": ["Ghost 15", "Glycerin 21", "Hyperion Elite 4", "기타"],
-        "기타": []
-    ]
-    
     var brandList: [String] {
-        brands.keys.sorted().filter { $0 != "기타" } + ["기타"]
+        ShoeCatalog.brandList
     }
     
     var modelList: [String] {
-        if let models = brands[selectedBrand] {
-            return models
-        }
-        return []
+        ShoeCatalog.modelList(for: selectedBrand)
     }
     
     // Computed Name
     var effectiveShoesName: String {
-        if selectedBrand == "기타" {
-            return "\(customBrand) \(customModel)"
-        } else if selectedModel == "기타" {
-            return "\(selectedBrand) \(customModel)"
-        } else {
-            return "\(selectedBrand) \(selectedModel)"
-        }
+        ShoeCatalog.shoesName(
+            selectedBrand: selectedBrand,
+            selectedModel: selectedModel,
+            customBrand: customBrand,
+            customModel: customModel
+        )
     }
     
     init(useCase: AddShoesUseCase) {
@@ -113,9 +101,9 @@ extension AddShoesViewModel {
             case .customBrand:
                 return nil
             case .customModel:
-                return viewModel.selectedBrand == "기타" ? .customBrand : nil
+                return viewModel.selectedBrand == ShoeCatalog.other ? .customBrand : nil
             case .usage:
-                if viewModel.selectedBrand == "기타" || viewModel.selectedModel == "기타" {
+                if viewModel.selectedBrand == ShoeCatalog.other || viewModel.selectedModel == ShoeCatalog.other {
                     return .customModel
                 }
                 return nil

--- a/Run Mile/Presentation/1.Shoes/1-2.ShoesDetail/Components/ShoesDetailHeaderView.swift
+++ b/Run Mile/Presentation/1.Shoes/1-2.ShoesDetail/Components/ShoesDetailHeaderView.swift
@@ -1,0 +1,111 @@
+//
+//  ShoesDetailHeaderView.swift
+//  Run Mile
+//
+//  Created by Codex on 5/8/26.
+//
+
+import SwiftUI
+
+
+struct ShoesDetailHeaderView: View {
+    let shoes: Shoes
+    let brand: String
+    let model: String
+    let onImageTap: () -> Void
+    let onHallOfFameTap: () -> Void
+    
+    var body: some View {
+        VStack(spacing: 16) {
+            shoeImageView
+            shoeInfoView
+        }
+        .padding(.top, 20)
+        .padding(.horizontal)
+    }
+    
+    private var shoeImageView: some View {
+        Group {
+            if let uiImage = UIImage(data: shoes.image) {
+                Image(uiImage: uiImage)
+                    .resizable()
+                    .scaledToFit()
+                    .frame(height: 200)
+                    .clipShape(RoundedRectangle(cornerRadius: RunMileRadius.image, style: .continuous))
+                    .runMileBrutalCard(cornerRadius: RunMileRadius.image)
+                    .onTapGesture(perform: onImageTap)
+            } else {
+                Image(systemName: "shoe.fill")
+                    .resizable()
+                    .scaledToFit()
+                    .frame(height: 150)
+                    .foregroundStyle(RunMileColor.mutedForeground)
+                    .padding(30)
+                    .runMileBrutalCard(cornerRadius: RunMileRadius.image)
+            }
+        }
+    }
+    
+    private var shoeInfoView: some View {
+        VStack(spacing: 8) {
+            Text(brand.uppercased())
+                .font(.caption)
+                .fontWeight(.bold)
+                .foregroundStyle(RunMileColor.primaryForeground)
+                .padding(.horizontal, 10)
+                .padding(.vertical, 4)
+                .background {
+                    RoundedRectangle(cornerRadius: RunMileRadius.progress, style: .continuous)
+                        .fill(RunMileColor.primary)
+                }
+            
+            Text(model)
+                .font(.title)
+                .fontWeight(.heavy)
+                .foregroundStyle(RunMileColor.foreground)
+                .multilineTextAlignment(.center)
+            
+            Text("\"\(shoes.nickname)\"")
+                .font(.body)
+                .fontWeight(.medium)
+                .foregroundStyle(RunMileColor.mutedForeground)
+            
+            if shoes.isGradutate {
+                hallOfFameBadge
+            }
+            
+            if !shoes.isGradutate && shoes.isOverGoal {
+                hallOfFameButton
+            }
+        }
+    }
+    
+    private var hallOfFameBadge: some View {
+        Label("명예의 전당", systemImage: "laurel.leading")
+            .font(.caption)
+            .fontWeight(.bold)
+            .foregroundStyle(RunMileColor.secondaryForeground)
+            .padding(.horizontal, 12)
+            .padding(.vertical, 6)
+            .background {
+                RoundedRectangle(cornerRadius: RunMileRadius.progress, style: .continuous)
+                    .fill(RunMileColor.secondary)
+            }
+            .overlay {
+                RoundedRectangle(cornerRadius: RunMileRadius.progress, style: .continuous)
+                    .stroke(RunMileColor.border, lineWidth: RunMileStroke.hairline)
+            }
+            .padding(.top, 4)
+    }
+    
+    private var hallOfFameButton: some View {
+        Button(action: onHallOfFameTap) {
+            HStack {
+                Image(systemName: "trophy.fill")
+                Text("명예의 전당 입성")
+            }
+            .runMileSecondaryButton()
+        }
+        .padding(.top, 8)
+    }
+}

--- a/Run Mile/Presentation/1.Shoes/1-2.ShoesDetail/Components/ShoesDetailManagementSection.swift
+++ b/Run Mile/Presentation/1.Shoes/1-2.ShoesDetail/Components/ShoesDetailManagementSection.swift
@@ -1,0 +1,129 @@
+//
+//  ShoesDetailManagementSection.swift
+//  Run Mile
+//
+//  Created by Codex on 5/8/26.
+//
+
+import SwiftUI
+
+
+struct ShoesDetailManagementSection: View {
+    let workoutCount: Int
+    let currentMileageText: String
+    let onEditInfoTap: () -> Void
+    let onWorkoutManagementTap: () -> Void
+    
+    var body: some View {
+        VStack(alignment: .leading, spacing: 14) {
+            Text("신발 관리")
+                .font(.title3)
+                .fontWeight(.bold)
+                .foregroundStyle(RunMileColor.foreground)
+            
+            VStack(spacing: 0) {
+                ShoesManagementActionRow(
+                    title: "신발 정보 수정",
+                    subtitle: "브랜드, 이름, 용도, 목표 마일리지",
+                    icon: "pencil.line",
+                    tint: RunMileColor.accent,
+                    action: onEditInfoTap
+                )
+                
+                RunMileDivider()
+                
+                ShoesManagementActionRow(
+                    title: "연결된 운동 관리",
+                    subtitle: "\(workoutCount)개 운동 · \(currentMileageText)km",
+                    icon: "figure.run",
+                    tint: RunMileColor.primary,
+                    action: onWorkoutManagementTap
+                )
+            }
+            .runMileBrutalCard()
+        }
+        .padding(.horizontal)
+    }
+}
+
+
+struct ShoesDetailDangerSection: View {
+    let onDeleteTap: () -> Void
+    
+    var body: some View {
+        VStack(alignment: .leading, spacing: 14) {
+            Text("기타 관리")
+                .font(.title3)
+                .fontWeight(.bold)
+                .foregroundStyle(RunMileColor.foreground)
+            
+            ShoesManagementActionRow(
+                title: "신발 삭제",
+                subtitle: "운동 기록은 유지하고 신발 연결만 해제",
+                icon: "trash",
+                tint: RunMileColor.primary,
+                action: onDeleteTap
+            )
+            .runMileBrutalCard()
+        }
+        .padding(.horizontal)
+    }
+}
+
+
+private struct ShoesManagementActionRow: View {
+    let title: String
+    let subtitle: String
+    let icon: String
+    let tint: Color
+    let action: () -> Void
+    
+    var body: some View {
+        Button(action: action) {
+            HStack(spacing: 14) {
+                Image(systemName: icon)
+                    .font(.headline.weight(.bold))
+                    .frame(width: 36, height: 36)
+                    .foregroundStyle(tint)
+                    .background(RunMileColor.muted, in: RoundedRectangle(cornerRadius: RunMileRadius.small, style: .continuous))
+                    .overlay {
+                        RoundedRectangle(cornerRadius: RunMileRadius.small, style: .continuous)
+                            .stroke(RunMileColor.border, lineWidth: RunMileStroke.border)
+                    }
+                
+                VStack(alignment: .leading, spacing: 4) {
+                    Text(title)
+                        .font(.subheadline.weight(.black))
+                        .foregroundStyle(RunMileColor.foreground)
+                    
+                    Text(subtitle)
+                        .font(.caption)
+                        .fontWeight(.semibold)
+                        .foregroundStyle(RunMileColor.mutedForeground)
+                        .lineLimit(1)
+                }
+                
+                Spacer()
+                
+                Image(systemName: "chevron.right")
+                    .font(.footnote.weight(.black))
+                    .foregroundStyle(RunMileColor.mutedForeground)
+            }
+            .padding(.vertical, 14)
+            .padding(.horizontal, 16)
+            .frame(maxWidth: .infinity, alignment: .leading)
+            .contentShape(Rectangle())
+        }
+        .buttonStyle(.plain)
+    }
+}
+
+
+private struct RunMileDivider: View {
+    var body: some View {
+        Rectangle()
+            .fill(RunMileColor.border.opacity(0.12))
+            .frame(height: 1)
+            .padding(.leading, 66)
+    }
+}

--- a/Run Mile/Presentation/1.Shoes/1-2.ShoesDetail/Components/ShoesDetailMileageCardView.swift
+++ b/Run Mile/Presentation/1.Shoes/1-2.ShoesDetail/Components/ShoesDetailMileageCardView.swift
@@ -1,0 +1,122 @@
+//
+//  ShoesDetailMileageCardView.swift
+//  Run Mile
+//
+//  Created by Codex on 5/8/26.
+//
+
+import SwiftUI
+
+
+struct ShoesDetailMileageCardView: View {
+    let shoes: Shoes
+    let remainingPercentText: String
+    let lifeSpanRatio: Double
+    let statusColor: Color
+    let statusForegroundColor: Color
+    let averageDistance: String
+    
+    var body: some View {
+        VStack(alignment: .leading, spacing: 16) {
+            mileageHeaderView
+            progressView
+            
+            Divider()
+            
+            detailStatsView
+        }
+        .padding(20)
+        .runMileBrutalCard()
+        .padding(.horizontal)
+    }
+    
+    private var mileageHeaderView: some View {
+        HStack {
+            Label("마일리지 상태", systemImage: "chart.bar.fill")
+                .font(.headline)
+                .foregroundStyle(RunMileColor.foreground)
+            
+            Spacer()
+            
+            Text(remainingPercentText)
+                .font(.caption)
+                .fontWeight(.bold)
+                .padding(.horizontal, 8)
+                .padding(.vertical, 4)
+                .background {
+                    RoundedRectangle(cornerRadius: RunMileRadius.progress, style: .continuous)
+                        .fill(statusColor)
+                }
+                .foregroundStyle(statusForegroundColor)
+                .overlay {
+                    RoundedRectangle(cornerRadius: RunMileRadius.progress, style: .continuous)
+                        .stroke(RunMileColor.border, lineWidth: RunMileStroke.hairline)
+                }
+        }
+    }
+    
+    private var progressView: some View {
+        VStack(spacing: 8) {
+            GeometryReader { geometry in
+                ZStack(alignment: .leading) {
+                    RoundedRectangle(cornerRadius: RunMileRadius.progress, style: .continuous)
+                        .fill(RunMileColor.muted)
+                        .frame(height: 12)
+                    
+                    RoundedRectangle(cornerRadius: RunMileRadius.progress, style: .continuous)
+                        .fill(statusColor)
+                        .frame(width: geometry.size.width * max(lifeSpanRatio, 0.05), height: 12)
+                }
+            }
+            .frame(height: 12)
+            
+            HStack {
+                Text(shoes.getCurrentMileage + "km")
+                    .font(.title3)
+                    .fontWeight(.bold)
+                    .foregroundStyle(statusColor)
+                
+                Text("사용")
+                    .font(.caption)
+                    .foregroundStyle(RunMileColor.mutedForeground)
+                    .padding(.leading, -4)
+                
+                Spacer()
+                
+                Text(shoes.getGoalMileage + "km")
+                    .font(.headline)
+                    .foregroundStyle(RunMileColor.mutedForeground)
+                
+                Text("목표")
+                    .font(.caption)
+                    .foregroundStyle(RunMileColor.mutedForeground)
+                    .padding(.leading, -4)
+            }
+            .padding(.top, 4)
+        }
+    }
+    
+    private var detailStatsView: some View {
+        HStack(spacing: 20) {
+            VStack(alignment: .leading) {
+                Text("주행 횟수")
+                    .font(.caption)
+                    .foregroundStyle(RunMileColor.mutedForeground)
+                
+                Text("\(shoes.workouts.count)회")
+                    .font(.headline)
+                    .foregroundStyle(RunMileColor.foreground)
+            }
+            
+            VStack(alignment: .leading) {
+                Text("평균 거리")
+                    .font(.caption)
+                    .foregroundStyle(RunMileColor.mutedForeground)
+                
+                Text(averageDistance)
+                    .font(.headline)
+                    .foregroundStyle(RunMileColor.foreground)
+            }
+        }
+    }
+}

--- a/Run Mile/Presentation/1.Shoes/1-2.ShoesDetail/Components/ShoesDetailWorkoutHistoryView.swift
+++ b/Run Mile/Presentation/1.Shoes/1-2.ShoesDetail/Components/ShoesDetailWorkoutHistoryView.swift
@@ -1,0 +1,67 @@
+//
+//  ShoesDetailWorkoutHistoryView.swift
+//  Run Mile
+//
+//  Created by Codex on 5/8/26.
+//
+
+import SwiftUI
+
+
+struct ShoesDetailWorkoutHistoryView: View {
+    let workouts: [Workout]
+    let shoesName: String
+    let onWorkoutTap: (Workout) -> Void
+    
+    var body: some View {
+        VStack(alignment: .leading, spacing: 16) {
+            Text("최근 활동")
+                .font(.title3)
+                .fontWeight(.bold)
+                .foregroundStyle(RunMileColor.foreground)
+                .padding(.horizontal)
+            
+            if workouts.isEmpty {
+                emptyStateView
+            } else {
+                workoutListView
+            }
+        }
+    }
+    
+    private var emptyStateView: some View {
+        VStack(spacing: 12) {
+            Image(systemName: "figure.run.circle")
+                .font(.system(size: 40))
+                .foregroundStyle(RunMileColor.foreground)
+            
+            Text("아직 기록된 운동이 없습니다.")
+                .font(.subheadline)
+                .foregroundStyle(RunMileColor.mutedForeground)
+        }
+        .frame(maxWidth: .infinity)
+        .padding(.vertical, 40)
+        .background {
+            RoundedRectangle(cornerRadius: RunMileRadius.card, style: .continuous)
+                .fill(RunMileColor.muted)
+        }
+        .overlay {
+            RoundedRectangle(cornerRadius: RunMileRadius.card, style: .continuous)
+                .stroke(RunMileColor.border, lineWidth: RunMileStroke.border)
+        }
+        .padding(.horizontal)
+    }
+    
+    private var workoutListView: some View {
+        LazyVStack(spacing: 12) {
+            ForEach(workouts) { workout in
+                WorkoutHistoryCell(workout: workout, registeredShoeName: shoesName)
+                    .contentShape(Rectangle())
+                    .onTapGesture {
+                        onWorkoutTap(workout)
+                    }
+            }
+        }
+        .padding(.horizontal)
+    }
+}

--- a/Run Mile/Presentation/1.Shoes/1-2.ShoesDetail/Sheets/ShoesDeleteSheetView.swift
+++ b/Run Mile/Presentation/1.Shoes/1-2.ShoesDetail/Sheets/ShoesDeleteSheetView.swift
@@ -1,0 +1,63 @@
+//
+//  ShoesDeleteSheetView.swift
+//  Run Mile
+//
+//  Created by Codex on 5/8/26.
+//
+
+import SwiftUI
+
+
+struct ShoesDeleteSheetView: View {
+    let shoesName: String
+    let workoutCount: Int
+    let onCancel: () -> Void
+    let onDelete: () -> Void
+    
+    var body: some View {
+        VStack(alignment: .leading, spacing: 22) {
+            messageView
+            actionButtonsView
+        }
+        .padding(20)
+        .frame(maxWidth: .infinity, maxHeight: .infinity, alignment: .topLeading)
+        .background(RunMileColor.background)
+    }
+    
+    private var messageView: some View {
+        VStack(alignment: .leading, spacing: 10) {
+            Image(systemName: "trash.fill")
+                .font(.title.weight(.black))
+                .foregroundStyle(RunMileColor.primary)
+                .frame(width: 52, height: 52)
+                .background(RunMileColor.muted, in: RoundedRectangle(cornerRadius: RunMileRadius.image, style: .continuous))
+                .overlay {
+                    RoundedRectangle(cornerRadius: RunMileRadius.image, style: .continuous)
+                        .stroke(RunMileColor.border, lineWidth: RunMileStroke.border)
+                }
+            
+            Text("신발을 삭제할까요?")
+                .font(.title2.weight(.black))
+                .foregroundStyle(RunMileColor.foreground)
+            
+            Text("\(shoesName)의 신발 정보가 삭제됩니다.\n연결된 \(workoutCount)개 운동 기록은 유지되고 신발 마일리지 반영만 해제됩니다.")
+                .font(.subheadline.weight(.semibold))
+                .foregroundStyle(RunMileColor.mutedForeground)
+                .fixedSize(horizontal: false, vertical: true)
+        }
+    }
+    
+    private var actionButtonsView: some View {
+        VStack(spacing: 12) {
+            Button(action: onDelete) {
+                Text("삭제하기")
+                    .runMilePrimaryButton()
+            }
+            
+            Button(action: onCancel) {
+                Text("취소")
+                    .runMileSecondaryButton()
+            }
+        }
+    }
+}

--- a/Run Mile/Presentation/1.Shoes/1-2.ShoesDetail/Sheets/ShoesEditSheetView.swift
+++ b/Run Mile/Presentation/1.Shoes/1-2.ShoesDetail/Sheets/ShoesEditSheetView.swift
@@ -1,0 +1,208 @@
+//
+//  ShoesEditSheetView.swift
+//  Run Mile
+//
+//  Created by Codex on 5/8/26.
+//
+
+import SwiftUI
+
+
+struct ShoesEditSheetView: View {
+    @Binding var brand: String
+    @Binding var model: String
+    @Binding var customBrand: String
+    @Binding var customModel: String
+    @Binding var usage: String
+    @Binding var goalMileage: String
+    let brandList: [String]
+    let modelList: [String]
+    let isDoneEnabled: Bool
+    let onCancel: () -> Void
+    let onDone: () -> Void
+    
+    var body: some View {
+        NavigationStack {
+            ScrollView {
+                VStack(alignment: .leading, spacing: 22) {
+                    headerView
+                    inputFieldsView
+                    recommendedMileageView
+                    doneButton
+                }
+                .padding(20)
+            }
+            .background(RunMileColor.background)
+            .toolbar {
+                ToolbarItem(placement: .topBarTrailing) {
+                    Button("닫기", action: onCancel)
+                        .foregroundStyle(RunMileColor.primary)
+                }
+            }
+        }
+    }
+    
+    private var headerView: some View {
+        VStack(alignment: .leading, spacing: 8) {
+            Text("신발 정보 수정")
+                .font(.title2.weight(.black))
+                .foregroundStyle(RunMileColor.foreground)
+            
+            Text("브랜드, 이름, 용도, 목표 마일리지를 한 번에 관리합니다.")
+                .font(.subheadline.weight(.semibold))
+                .foregroundStyle(RunMileColor.mutedForeground)
+        }
+    }
+    
+    private var inputFieldsView: some View {
+        VStack(spacing: 16) {
+            ShoesEditPickerField(
+                title: "브랜드",
+                icon: "tag.fill",
+                selection: $brand,
+                items: brandList,
+                placeholder: "브랜드를 선택해주세요"
+            )
+            
+            if brand != ShoeCatalog.other {
+                ShoesEditPickerField(
+                    title: "모델명",
+                    icon: "shoe.fill",
+                    selection: $model,
+                    items: modelList,
+                    placeholder: "모델을 선택해주세요"
+                )
+            }
+            
+            if brand == ShoeCatalog.other || model == ShoeCatalog.other {
+                customInputFieldsView
+            }
+            
+            ShoesEditField(title: "용도", icon: "figure.run", text: $usage, maxLength: 10)
+            ShoesEditField(title: "목표 마일리지 (km)", icon: "flag.checkered", text: $goalMileage, keyboardType: .numberPad)
+        }
+    }
+    
+    private var customInputFieldsView: some View {
+        VStack(spacing: 12) {
+            if brand == ShoeCatalog.other {
+                ShoesEditField(title: "브랜드 직접 입력", icon: "tag.fill", text: $customBrand)
+            }
+            
+            ShoesEditField(title: "모델명 직접 입력", icon: "shoe.fill", text: $customModel)
+        }
+        .transition(.move(edge: .top).combined(with: .opacity))
+    }
+    
+    private var recommendedMileageView: some View {
+        VStack(alignment: .leading, spacing: 10) {
+            Label("추천 목표", systemImage: "sparkles")
+                .font(.caption.weight(.bold))
+                .foregroundStyle(RunMileColor.mutedForeground)
+            
+            HStack(spacing: 8) {
+                ForEach(["300", "500", "700", "1000"], id: \.self) { mileage in
+                    Button {
+                        goalMileage = mileage
+                    } label: {
+                        Text("\(mileage)km")
+                            .font(.caption.weight(.black))
+                            .foregroundStyle(goalMileage == mileage ? RunMileColor.secondaryForeground : RunMileColor.foreground)
+                            .frame(maxWidth: .infinity)
+                            .padding(.vertical, 10)
+                            .background(goalMileage == mileage ? RunMileColor.secondary : RunMileColor.card)
+                            .overlay {
+                                RoundedRectangle(cornerRadius: RunMileRadius.button, style: .continuous)
+                                    .stroke(RunMileColor.border, lineWidth: RunMileStroke.border)
+                            }
+                    }
+                    .buttonStyle(.plain)
+                }
+            }
+        }
+    }
+    
+    private var doneButton: some View {
+        Button(action: onDone) {
+            Text("수정 완료")
+                .runMilePrimaryButton(isEnabled: isDoneEnabled)
+        }
+        .disabled(!isDoneEnabled)
+    }
+}
+
+
+private struct ShoesEditPickerField: View {
+    let title: String
+    let icon: String
+    @Binding var selection: String
+    let items: [String]
+    let placeholder: String
+    
+    var body: some View {
+        VStack(alignment: .leading, spacing: 8) {
+            Label(title, systemImage: icon)
+                .font(.caption.weight(.bold))
+                .foregroundStyle(RunMileColor.mutedForeground)
+            
+            Picker(placeholder, selection: $selection) {
+                ForEach(items, id: \.self) { item in
+                    Text(item).tag(item)
+                }
+            }
+            .pickerStyle(.menu)
+            .tint(RunMileColor.foreground)
+            .frame(maxWidth: .infinity, minHeight: 52, alignment: .leading)
+            .padding(.horizontal, 14)
+            .background(RunMileColor.card, in: RoundedRectangle(cornerRadius: RunMileRadius.input, style: .continuous))
+            .overlay {
+                RoundedRectangle(cornerRadius: RunMileRadius.input, style: .continuous)
+                    .stroke(RunMileColor.input, lineWidth: RunMileStroke.border)
+            }
+        }
+    }
+}
+
+
+private struct ShoesEditField: View {
+    let title: String
+    let icon: String
+    @Binding var text: String
+    var keyboardType: UIKeyboardType = .default
+    var maxLength: Int?
+    
+    var body: some View {
+        VStack(alignment: .leading, spacing: 8) {
+            HStack {
+                Label(title, systemImage: icon)
+                    .font(.caption.weight(.bold))
+                    .foregroundStyle(RunMileColor.mutedForeground)
+                
+                Spacer()
+                
+                if let maxLength {
+                    Text("\(text.count) / \(maxLength)")
+                        .font(.caption2)
+                        .fontWeight(.semibold)
+                        .foregroundStyle(text.count > maxLength ? RunMileColor.primary : RunMileColor.mutedForeground)
+                }
+            }
+            
+            TextField(title, text: $text)
+                .font(.body.weight(.semibold))
+                .foregroundStyle(RunMileColor.foreground)
+                .padding()
+                .background(RunMileColor.card, in: RoundedRectangle(cornerRadius: RunMileRadius.input, style: .continuous))
+                .overlay {
+                    RoundedRectangle(cornerRadius: RunMileRadius.input, style: .continuous)
+                        .stroke(RunMileColor.input, lineWidth: RunMileStroke.border)
+                }
+                .keyboardType(keyboardType)
+                .onChange(of: text) { _, newValue in
+                    if let maxLength, newValue.count > maxLength {
+                        text = String(newValue.prefix(maxLength))
+                    }
+                }
+        }
+    }
+}

--- a/Run Mile/Presentation/1.Shoes/1-2.ShoesDetail/Sheets/ShoesWorkoutManagementSheet.swift
+++ b/Run Mile/Presentation/1.Shoes/1-2.ShoesDetail/Sheets/ShoesWorkoutManagementSheet.swift
@@ -1,0 +1,161 @@
+//
+//  ShoesWorkoutManagementSheet.swift
+//  Run Mile
+//
+//  Created by Codex on 5/8/26.
+//
+
+import SwiftUI
+
+
+struct ShoesWorkoutManagementSheet: View {
+    let workouts: [Workout]
+    @Binding var selectedWorkoutIDs: Set<UUID>
+    let onCancel: () -> Void
+    let onRemove: () -> Void
+    
+    private var totalDistance: String {
+        let kilometer = workouts.reduce(0) { $0 + $1.distance } / 1000
+        return String(format: "%.2fkm", kilometer)
+    }
+    
+    var body: some View {
+        NavigationStack {
+            VStack(spacing: 0) {
+                headerView
+                contentView
+            }
+            .safeAreaInset(edge: .bottom) {
+                removeButtonContainer
+            }
+            .background(RunMileColor.background)
+            .toolbar {
+                ToolbarItem(placement: .topBarTrailing) {
+                    Button("닫기", action: onCancel)
+                        .foregroundStyle(RunMileColor.primary)
+                }
+            }
+        }
+    }
+    
+    private var headerView: some View {
+        VStack(alignment: .leading, spacing: 8) {
+            Text("연결된 운동")
+                .font(.title2.weight(.black))
+                .foregroundStyle(RunMileColor.foreground)
+            
+            Text("\(workouts.count)개 운동 · \(totalDistance)")
+                .font(.subheadline.weight(.semibold))
+                .foregroundStyle(RunMileColor.mutedForeground)
+        }
+        .frame(maxWidth: .infinity, alignment: .leading)
+        .padding(20)
+    }
+    
+    @ViewBuilder
+    private var contentView: some View {
+        if workouts.isEmpty {
+            emptyStateView
+        } else {
+            workoutListView
+        }
+    }
+    
+    private var emptyStateView: some View {
+        VStack(spacing: 12) {
+            Image(systemName: "link.badge.plus")
+                .font(.system(size: 38, weight: .bold))
+                .foregroundStyle(RunMileColor.mutedForeground)
+            
+            Text("연결된 운동이 없습니다.")
+                .font(.subheadline.weight(.bold))
+                .foregroundStyle(RunMileColor.mutedForeground)
+        }
+        .frame(maxWidth: .infinity, maxHeight: .infinity)
+    }
+    
+    private var workoutListView: some View {
+        ScrollView {
+            LazyVStack(spacing: 12) {
+                ForEach(workouts) { workout in
+                    LinkedWorkoutRow(
+                        workout: workout,
+                        isSelected: selectedWorkoutIDs.contains(workout.id),
+                        onTap: { toggleWorkout(workout.id) }
+                    )
+                }
+            }
+            .padding(.horizontal, 20)
+            .padding(.bottom, 100)
+        }
+    }
+    
+    private var removeButtonContainer: some View {
+        VStack(spacing: 10) {
+            Button(action: onRemove) {
+                Text(selectedWorkoutIDs.isEmpty ? "선택한 운동 연결 해제" : "\(selectedWorkoutIDs.count)개 운동 연결 해제")
+                    .runMilePrimaryButton(isEnabled: !selectedWorkoutIDs.isEmpty)
+            }
+            .disabled(selectedWorkoutIDs.isEmpty)
+        }
+        .padding(20)
+        .background(RunMileColor.background)
+    }
+    
+    private func toggleWorkout(_ id: UUID) {
+        if selectedWorkoutIDs.contains(id) {
+            selectedWorkoutIDs.remove(id)
+        } else {
+            selectedWorkoutIDs.insert(id)
+        }
+    }
+}
+
+
+private struct LinkedWorkoutRow: View {
+    let workout: Workout
+    let isSelected: Bool
+    let onTap: () -> Void
+    
+    var body: some View {
+        Button(action: onTap) {
+            HStack(spacing: 14) {
+                Image(systemName: isSelected ? "checkmark.circle.fill" : "minus.circle")
+                    .font(.title3.weight(.bold))
+                    .foregroundStyle(isSelected ? RunMileColor.primary : RunMileColor.mutedForeground)
+                
+                VStack(alignment: .leading, spacing: 8) {
+                    Text(workout.date.koreanMonthDay)
+                        .font(.caption.weight(.black))
+                        .foregroundStyle(RunMileColor.primary)
+                    
+                    Text("\(workout.calculatedDistance) km")
+                        .font(.title3.weight(.black))
+                        .foregroundStyle(RunMileColor.foreground)
+                    
+                    HStack(spacing: 10) {
+                        Label(workout.avgPace, systemImage: "stopwatch")
+                        Label(workout.time.toKoreanHourMinuteDuration(), systemImage: "clock")
+                    }
+                    .font(.caption.weight(.semibold))
+                    .foregroundStyle(RunMileColor.mutedForeground)
+                }
+                
+                Spacer()
+                
+                Text("연결 해제")
+                    .font(.caption.weight(.black))
+                    .foregroundStyle(RunMileColor.primary)
+                    .padding(.horizontal, 10)
+                    .padding(.vertical, 8)
+                    .overlay {
+                        RoundedRectangle(cornerRadius: RunMileRadius.button, style: .continuous)
+                            .stroke(RunMileColor.primary, lineWidth: RunMileStroke.border)
+                    }
+            }
+            .padding(16)
+            .runMileBrutalCard()
+        }
+        .buttonStyle(.plain)
+    }
+}

--- a/Run Mile/Presentation/1.Shoes/1-2.ShoesDetail/ShoesDetailView.swift
+++ b/Run Mile/Presentation/1.Shoes/1-2.ShoesDetail/ShoesDetailView.swift
@@ -18,244 +18,89 @@ struct ShoesDetailView: View {
     var body: some View {
         ScrollView {
             VStack(spacing: 24) {
-                // MARK: - Hero Section
-                headerView
+                ShoesDetailHeaderView(
+                    shoes: viewModel.shoes,
+                    brand: viewModel.shoeBrand,
+                    model: viewModel.shoeModel,
+                    onImageTap: viewModel.imageTapped,
+                    onHallOfFameTap: viewModel.HOFButtonTapped
+                )
                 
-                // MARK: - Mileage Section
-                mileageCardView
+                ShoesDetailMileageCardView(
+                    shoes: viewModel.shoes,
+                    remainingPercentText: viewModel.remainingPercentText,
+                    lifeSpanRatio: viewModel.lifeSpanRatio,
+                    statusColor: viewModel.statusColor,
+                    statusForegroundColor: viewModel.statusForegroundColor,
+                    averageDistance: viewModel.averageDistance
+                )
                 
-                // MARK: - Workout History
-                workoutHistoryList
+                ShoesDetailManagementSection(
+                    workoutCount: viewModel.shoes.workouts.count,
+                    currentMileageText: viewModel.shoes.getCurrentMileage,
+                    onEditInfoTap: viewModel.editInfoButtonTapped,
+                    onWorkoutManagementTap: viewModel.workoutManagementButtonTapped
+                )
+                
+                ShoesDetailWorkoutHistoryView(
+                    workouts: viewModel.shoes.workouts,
+                    shoesName: viewModel.shoes.shoesName,
+                    onWorkoutTap: viewModel.workoutCellTapped
+                )
+                
+                ShoesDetailDangerSection(
+                    onDeleteTap: viewModel.deleteManagementButtonTapped
+                )
             }
             .padding(.bottom, 40)
         }
         .background(RunMileColor.background)
         .navigationTitle(viewModel.shoeModel)
         .navigationBarTitleDisplayMode(.inline)
+        .sheet(item: $viewModel.activeManagementSheet, content: managementSheet)
     }
     
-    // MARK: - Components
-    
-    private var headerView: some View {
-        VStack(spacing: 16) {
-            // Shoe Image
-            if let uiImage = UIImage(data: viewModel.shoes.image) {
-                Image(uiImage: uiImage)
-                    .resizable()
-                    .scaledToFit()
-                    .frame(height: 200)
-                    .clipShape(RoundedRectangle(cornerRadius: RunMileRadius.image, style: .continuous))
-                    .runMileBrutalCard(cornerRadius: RunMileRadius.image)
-                    .onTapGesture {
-                        viewModel.imageTapped()
-                    }
-            } else {
-                Image(systemName: "shoe.fill")
-                    .resizable()
-                    .scaledToFit()
-                    .frame(height: 150)
-                    .foregroundStyle(RunMileColor.mutedForeground)
-                    .padding(30)
-                    .runMileBrutalCard(cornerRadius: RunMileRadius.image)
-            }
-            
-            // Text Info
-            VStack(spacing: 8) {
-                Text(viewModel.shoeBrand.uppercased())
-                    .font(.caption)
-                    .fontWeight(.bold)
-                    .foregroundStyle(RunMileColor.primaryForeground)
-                    .padding(.horizontal, 10)
-                    .padding(.vertical, 4)
-                    .background {
-                        RoundedRectangle(cornerRadius: RunMileRadius.progress, style: .continuous)
-                            .fill(RunMileColor.primary)
-                    }
-                
-                Text(viewModel.shoeModel)
-                    .font(.title)
-                    .fontWeight(.heavy)
-                    .foregroundStyle(RunMileColor.foreground)
-                    .multilineTextAlignment(.center)
-                
-                Text("\"\(viewModel.shoes.nickname)\"")
-                    .font(.body)
-                    .fontWeight(.medium)
-                    .foregroundStyle(RunMileColor.mutedForeground)
-                
-                if viewModel.shoes.isGradutate {
-                    Label("명예의 전당", systemImage: "laurel.leading")
-                        .font(.caption)
-                        .fontWeight(.bold)
-                        .foregroundStyle(RunMileColor.secondaryForeground)
-                        .padding(.horizontal, 12)
-                        .padding(.vertical, 6)
-                        .background {
-                            RoundedRectangle(cornerRadius: RunMileRadius.progress, style: .continuous)
-                                .fill(RunMileColor.secondary)
-                        }
-                        .overlay {
-                            RoundedRectangle(cornerRadius: RunMileRadius.progress, style: .continuous)
-                                .stroke(RunMileColor.border, lineWidth: RunMileStroke.hairline)
-                        }
-                        .padding(.top, 4)
-                }
-                
-                // Hall of Fame Action Button (If eligible and not yet graduated)
-                if !viewModel.shoes.isGradutate && viewModel.shoes.isOverGoal {
-                    Button {
-                        viewModel.HOFButtonTapped()
-                    } label: {
-                        HStack {
-                            Image(systemName: "trophy.fill")
-                            Text("명예의 전당 입성")
-                        }
-                        .runMileSecondaryButton()
-                    }
-                    .padding(.top, 8)
-                }
-            }
-        }
-        .padding(.top, 20)
-        .padding(.horizontal)
-    }
-    
-    private var mileageCardView: some View {
-        VStack(alignment: .leading, spacing: 16) {
-            HStack {
-                Label("마일리지 상태", systemImage: "chart.bar.fill")
-                    .font(.headline)
-                    .foregroundStyle(RunMileColor.foreground)
-                
-                Spacer()
-                
-                Text(viewModel.remainingPercentText)
-                    .font(.caption)
-                    .fontWeight(.bold)
-                    .padding(.horizontal, 8)
-                    .padding(.vertical, 4)
-                    .background {
-                        RoundedRectangle(cornerRadius: RunMileRadius.progress, style: .continuous)
-                            .fill(viewModel.statusColor)
-                    }
-                    .foregroundStyle(viewModel.statusForegroundColor)
-                    .overlay {
-                        RoundedRectangle(cornerRadius: RunMileRadius.progress, style: .continuous)
-                            .stroke(RunMileColor.border, lineWidth: RunMileStroke.hairline)
-                    }
-            }
-            
-            // Progress Bar
-            VStack(spacing: 8) {
-                GeometryReader { geometry in
-                    ZStack(alignment: .leading) {
-                        RoundedRectangle(cornerRadius: RunMileRadius.progress, style: .continuous)
-                            .fill(RunMileColor.muted)
-                            .frame(height: 12)
-                        
-                        RoundedRectangle(cornerRadius: RunMileRadius.progress, style: .continuous)
-                            .fill(viewModel.statusColor)
-                            .frame(width: geometry.size.width * max(viewModel.lifeSpanRatio, 0.05), height: 12)
-                    }
-                }
-                .frame(height: 12)
-                
-                HStack {
-                    Text(viewModel.shoes.getCurrentMileage + "km")
-                        .font(.title3)
-                        .fontWeight(.bold)
-                        .foregroundStyle(viewModel.statusColor)
-                    
-                    Text("사용")
-                        .font(.caption)
-                        .foregroundStyle(RunMileColor.mutedForeground)
-                        .padding(.leading, -4)
-                    
-                    Spacer()
-                    
-                    Text(viewModel.shoes.getGoalMileage + "km")
-                        .font(.headline)
-                        .foregroundStyle(RunMileColor.mutedForeground)
-                    Text("목표")
-                        .font(.caption)
-                        .foregroundStyle(RunMileColor.mutedForeground)
-                        .padding(.leading, -4)
-                }
-                .padding(.top, 4)
-            }
-            
-            Divider()
-            
-            // Detailed Stats
-            HStack(spacing: 20) {
-                VStack(alignment: .leading) {
-                    Text("주행 횟수")
-                        .font(.caption)
-                        .foregroundStyle(RunMileColor.mutedForeground)
-                    Text("\(viewModel.shoes.workouts.count)회")
-                        .font(.headline)
-                        .foregroundStyle(RunMileColor.foreground)
-                }
-                
-                VStack(alignment: .leading) {
-                    Text("평균 거리")
-                        .font(.caption)
-                        .foregroundStyle(RunMileColor.mutedForeground)
-                    
-                    Text(viewModel.averageDistance)
-                        .font(.headline)
-                        .foregroundStyle(RunMileColor.foreground)
-                }
-            }
-        }
-        .padding(20)
-        .runMileBrutalCard()
-        .padding(.horizontal)
-    }
-    
-    private var workoutHistoryList: some View {
-        VStack(alignment: .leading, spacing: 16) {
-            Text("최근 활동")
-                .font(.title3)
-                .fontWeight(.bold)
-                .foregroundStyle(RunMileColor.foreground)
-                .padding(.horizontal)
-            
-            if viewModel.shoes.workouts.isEmpty {
-                VStack(spacing: 12) {
-                    Image(systemName: "figure.run.circle")
-                        .font(.system(size: 40))
-                        .foregroundStyle(RunMileColor.foreground)
-                    Text("아직 기록된 운동이 없습니다.")
-                        .font(.subheadline)
-                        .foregroundStyle(RunMileColor.mutedForeground)
-                }
-                .frame(maxWidth: .infinity)
-                .padding(.vertical, 40)
-                .background {
-                    RoundedRectangle(cornerRadius: RunMileRadius.card, style: .continuous)
-                        .fill(RunMileColor.muted)
-                }
-                .overlay {
-                    RoundedRectangle(cornerRadius: RunMileRadius.card, style: .continuous)
-                        .stroke(RunMileColor.border, lineWidth: RunMileStroke.border)
-                }
-                .padding(.horizontal)
-            } else {
-                LazyVStack(spacing: 12) {
-                    ForEach(viewModel.shoes.workouts) { workout in
-                        WorkoutHistoryCell(workout: workout, registeredShoeName: viewModel.shoes.shoesName)
-                            .contentShape(Rectangle())
-                            .onTapGesture {
-                                viewModel.workoutCellTapped(workout)
-                            }
-                    }
-                }
-                .padding(.horizontal)
-            }
+    @ViewBuilder
+    private func managementSheet(_ sheet: ShoesDetailViewModel.ManagementSheet) -> some View {
+        switch sheet {
+        case .editInfo:
+            ShoesEditSheetView(
+                brand: $viewModel.editBrand,
+                model: $viewModel.editModel,
+                customBrand: $viewModel.editCustomBrand,
+                customModel: $viewModel.editCustomModel,
+                usage: $viewModel.editUsage,
+                goalMileage: $viewModel.editGoalMileage,
+                brandList: viewModel.editBrandList,
+                modelList: viewModel.editModelList,
+                isDoneEnabled: viewModel.isEditSaveEnabled,
+                onCancel: viewModel.dismissManagementSheet,
+                onDone: viewModel.saveEditedShoes
+            )
+            .presentationDetents([.large])
+            .presentationDragIndicator(.visible)
+        case .workouts:
+            ShoesWorkoutManagementSheet(
+                workouts: viewModel.shoes.workouts,
+                selectedWorkoutIDs: $viewModel.selectedWorkoutIDs,
+                onCancel: viewModel.dismissManagementSheet,
+                onRemove: viewModel.removeSelectedWorkouts
+            )
+            .presentationDetents([.large])
+            .presentationDragIndicator(.visible)
+        case .delete:
+            ShoesDeleteSheetView(
+                shoesName: viewModel.shoes.shoesName,
+                workoutCount: viewModel.shoes.workouts.count,
+                onCancel: viewModel.dismissManagementSheet,
+                onDelete: viewModel.deleteShoesFromSheet
+            )
+            .presentationDetents([.medium])
+            .presentationDragIndicator(.visible)
         }
     }
 }
+
 
 #Preview {
     NavigationStack {

--- a/Run Mile/Presentation/1.Shoes/1-2.ShoesDetail/ShoesDetailViewModel.swift
+++ b/Run Mile/Presentation/1.Shoes/1-2.ShoesDetail/ShoesDetailViewModel.swift
@@ -14,18 +14,19 @@ final class ShoesDetailViewModel {
     private let useCase: ShoesDetailUseCase
     
     public var shoes: Shoes
-    public var viewStatus: ViewStatus = .normal {
+    public var activeManagementSheet: ManagementSheet?
+    public var editBrand = ShoeCatalog.defaultBrand {
         didSet {
-            goalMileage = "\(Int(shoes.goalMileage))"
+            guard oldValue != editBrand else { return }
+            editModel = ShoeCatalog.defaultModel(for: editBrand)
         }
     }
-    
-    public var goalMileage: String = ""
-    public var selectedWorkouts: Set<UUID> = []
-    
-    public var isHallOfFame: Bool {
-        self.shoes.totalMileage >= self.shoes.goalMileage
-    }
+    public var editModel = ShoeCatalog.defaultModel
+    public var editCustomBrand = ""
+    public var editCustomModel = ""
+    public var editUsage = ""
+    public var editGoalMileage = ""
+    public var selectedWorkoutIDs: Set<UUID> = []
     
     public var averageDistance: String {
         let count = shoes.workouts.count
@@ -62,103 +63,120 @@ final class ShoesDetailViewModel {
         shoePresentationInfo.statusForegroundColor
     }
     
+    public var isEditSaveEnabled: Bool {
+        !effectiveEditedShoesName.isEmpty &&
+        !editUsage.trimmed.isEmpty &&
+        editGoalMileageValue != nil
+    }
+    
+    public var editBrandList: [String] {
+        ShoeCatalog.brandList
+    }
+    
+    public var editModelList: [String] {
+        ShoeCatalog.modelList(for: editBrand)
+    }
+    
     init(useCase: ShoesDetailUseCase, shoes: Shoes) {
         self.useCase = useCase
         self.shoes = shoes
     }
     
-    enum ViewStatus: Equatable {
-        case normal
-        case editing
+    /// 신발 상세 관리 액션에서 표시할 시트를 구분합니다.
+    enum ManagementSheet: Identifiable {
+        case editInfo
         case workouts
+        case delete
+        
+        var id: String {
+            switch self {
+            case .editInfo:
+                "editInfo"
+            case .workouts:
+                "workouts"
+            case .delete:
+                "delete"
+            }
+        }
     }
 }
 
 
 extension ShoesDetailViewModel {
+    /// 신발 정보 수정 시트를 열기 전 현재 신발 정보를 편집 상태에 반영합니다.
     @MainActor
-    public func editButtonTapped() {
-        self.viewStatus = .editing
+    public func editInfoButtonTapped() {
+        prepareEditSheet()
+        activeManagementSheet = .editInfo
     }
     
+    /// 연결된 운동 관리 시트를 열고 이전 선택 상태를 초기화합니다.
     @MainActor
-    public func cancelButtonTapped() {
-        selectedWorkouts.removeAll()
-        self.viewStatus = .normal
+    public func workoutManagementButtonTapped() {
+        selectedWorkoutIDs.removeAll()
+        activeManagementSheet = .workouts
     }
     
+    /// 신발 삭제 확인 시트를 표시합니다.
     @MainActor
-    public func choiceButtonTapped() {
-        self.viewStatus = .workouts
+    public func deleteManagementButtonTapped() {
+        activeManagementSheet = .delete
     }
     
+    /// 현재 표시 중인 신발 관리 시트를 닫습니다.
     @MainActor
-    public func deleteButtonTapped() {
-        let alert = AlertData(
-            title: "정말 삭제하시겠습니까?",
-            message: "삭제된 데이터는 되돌릴 수 없습니다.",
-            firstButton: .cancel(title: "취소") {},
-            secondButton: .ok(title: "삭제") {
-                self.deleteShoes()
-            }
-        )
+    public func dismissManagementSheet() {
+        activeManagementSheet = nil
+    }
+    
+    /// 편집 시트의 입력값으로 신발 정보를 저장합니다.
+    @MainActor
+    public func saveEditedShoes() {
+        guard let goalMileage = editGoalMileageValue else { return }
         
-        NavigationCoordinator.shared.push(alert)
-    }
-    
-    @MainActor
-    public func completeButtonTapped() {
         let modified = Shoes(
             id: shoes.id,
             image: shoes.image,
-            shoesName: shoes.shoesName,
-            nickname: shoes.nickname,
-            goalMileage: Double(goalMileage)!,
+            shoesName: effectiveEditedShoesName,
+            nickname: editUsage.trimmed,
+            goalMileage: goalMileage,
             currentMileage: shoes.currentMileage,
-            workouts: shoes.workouts
+            workouts: shoes.workouts,
+            isGraduate: shoes.isGradutate
         )
         
         Task {
-            do {
-                try await useCase.editShoes(shoes: modified)
-                self.shoes = modified
-                self.viewStatus = .normal
-            } catch {
-                NavigationCoordinator.shared.push(.init(
-                    title: "저장 과정 중 오류가 발생했습니다.",
-                    message: "같은 오류가 계속 발생할 시 문의 부탁드립니다.\n** \(error.localizedDescription)",
-                    firstButton: .cancel(title: "확인", action: {}),
-                    secondButton: nil
-                ))
-            }
+            await updateShoes(modified)
+        }
+    }
+    
+    /// 선택한 운동과 신발의 연결을 해제합니다.
+    @MainActor
+    public func removeSelectedWorkouts() {
+        guard !selectedWorkoutIDs.isEmpty else { return }
+        
+        let workoutIDs = selectedWorkoutIDs
+        let modified = makeShoes(removingWorkoutIDs: workoutIDs)
+        
+        Task {
+            await updateShoes(modified)
+            self.selectedWorkoutIDs.removeAll()
+        }
+    }
+    
+    /// 신발 삭제를 실행하고 삭제 완료 후 현재 탭에서 이전 화면으로 돌아갑니다.
+    @MainActor
+    public func deleteShoesFromSheet() {
+        let currentTab = NavigationCoordinator.shared.tabStatus
+        Task {
+            await deleteShoes(currentTab: currentTab)
         }
     }
     
     @MainActor
     public func workoutCellTapped(_ workout: Workout) {
-        switch self.viewStatus {
-        case .workouts:
-            if selectedWorkouts.contains(workout.id) {
-                selectedWorkouts.remove(workout.id)
-            } else {
-                selectedWorkouts.insert(workout.id)
-            }
-        default:
-            let currentTab = NavigationCoordinator.shared.tabStatus
-            NavigationCoordinator.shared.push(.workoutDetail(workout), tab: currentTab)
-        }
-    }
-    
-    @MainActor
-    public func deleteWorkoutsButtonTapped() {
-        let alert = AlertData(
-            title: "\(self.selectedWorkouts.count)개의 운동을 제거하시겠습니까?",
-            message: "제거된 운동은 추후에 다시 등록이 가능합니다!",
-            firstButton: .cancel(title: "취소", action: {}),
-            secondButton: .ok(title: "확인", action: self.deleteWorkouts)
-        )
-        
-        NavigationCoordinator.shared.push(alert)
+        let currentTab = NavigationCoordinator.shared.tabStatus
+        NavigationCoordinator.shared.push(.workoutDetail(workout), tab: currentTab)
     }
     
     @MainActor
@@ -183,63 +201,94 @@ extension ShoesDetailViewModel {
 
 // MARK: - Internal Function
 extension ShoesDetailViewModel {
-    private func deleteShoes() {
-        Task {
-            do {
-                try await useCase.deleteShoes(shoes: self.shoes)
-                let alert = AlertData(
-                    title: "삭제를 완료했습니다.",
-                    message: nil,
-                    firstButton: .cancel(title: "확인") {
-                        Task {
-                            await NavigationCoordinator.shared.pop(.shoes)
-                        }
-                    },
-                    secondButton: nil
-                )
-                
-                await NavigationCoordinator.shared.push(alert)
-                
-            } catch {
-                let alert = AlertData(
-                    title: "삭제 과정 중 오류가 발생했습니다.",
-                    message: "같은 오류가 계속 발생할 시 문의 부탁드립니다.\n** \(error.localizedDescription)",
-                    firstButton: .cancel(title: "확인", action: {}),
-                    secondButton: nil
-                )
-                
-                await NavigationCoordinator.shared.push(alert)
-            }
-        }
+    private func prepareEditSheet() {
+        let selection = ShoeCatalog.selection(for: shoes.shoesName)
+        
+        editBrand = selection.selectedBrand
+        editModel = selection.selectedModel
+        editCustomBrand = selection.customBrand
+        editCustomModel = selection.customModel
+        editUsage = shoes.nickname
+        editGoalMileage = shoes.getGoalMileage
     }
     
-    private func deleteWorkouts() {
-        let workout = shoes.workouts.filter { !selectedWorkouts.contains($0.id) }
+    private var effectiveEditedShoesName: String {
+        ShoeCatalog.shoesName(
+            selectedBrand: editBrand,
+            selectedModel: editModel,
+            customBrand: editCustomBrand,
+            customModel: editCustomModel
+        )
+    }
+    
+    private var editGoalMileageValue: Double? {
+        let value = Double(editGoalMileage.trimmed)
+        guard let value, value > 0 else { return nil }
+        return value
+    }
+    
+    /// 지정한 운동 ID를 제외한 신발 모델을 생성합니다.
+    private func makeShoes(removingWorkoutIDs workoutIDs: Set<UUID>) -> Shoes {
+        let remainingWorkouts = shoes.workouts.filter {
+            !workoutIDs.contains($0.id)
+        }
         
-        let modified = Shoes(
+        return Shoes(
             id: shoes.id,
             image: shoes.image,
             shoesName: shoes.shoesName,
             nickname: shoes.nickname,
             goalMileage: shoes.goalMileage,
             currentMileage: shoes.currentMileage,
-            workouts: workout
+            workouts: remainingWorkouts,
+            isGraduate: shoes.isGradutate
         )
-        
-        Task {
-            do {
-                try await useCase.editShoes(shoes: modified)
-                self.shoes.workouts = workout
-                self.selectedWorkouts.removeAll()
-                self.viewStatus = .normal
-            } catch {
-                await NavigationCoordinator.shared.push(.init(
-                    title: "저장 과정 중 오류가 발생했습니다.",
-                    message: "같은 오류가 계속 발생할 시 문의 부탁드립니다.\n** \(error.localizedDescription)",
-                    firstButton: .cancel(title: "확인", action: {}),
-                    secondButton: nil
-                ))
-            }
+    }
+    
+    /// 신발 변경사항을 저장하고 현재 화면 상태를 최신 데이터로 갱신합니다.
+    @MainActor
+    private func updateShoes(_ modified: Shoes) async {
+        do {
+            try await useCase.editShoes(shoes: modified)
+            self.shoes = modified
+            self.activeManagementSheet = nil
+        } catch {
+            NavigationCoordinator.shared.push(.init(
+                title: "저장 과정 중 오류가 발생했습니다.",
+                message: "같은 오류가 계속 발생할 시 문의 부탁드립니다.\n** \(error.localizedDescription)",
+                firstButton: .cancel(title: "확인", action: {}),
+                secondButton: nil
+            ))
+        }
+    }
+    
+    @MainActor
+    private func deleteShoes(currentTab: NavigationCoordinator.TabStatus) async {
+        do {
+            try await useCase.deleteShoes(shoes: self.shoes)
+            self.activeManagementSheet = nil
+            
+            let alert = AlertData(
+                title: "삭제를 완료했습니다.",
+                message: nil,
+                firstButton: .cancel(title: "확인") {
+                    Task {
+                        await NavigationCoordinator.shared.pop(currentTab)
+                    }
+                },
+                secondButton: nil
+            )
+            
+            NavigationCoordinator.shared.push(alert)
+        } catch {
+            let alert = AlertData(
+                title: "삭제 과정 중 오류가 발생했습니다.",
+                message: "같은 오류가 계속 발생할 시 문의 부탁드립니다.\n** \(error.localizedDescription)",
+                firstButton: .cancel(title: "확인", action: {}),
+                secondButton: nil
+            )
+            
+            NavigationCoordinator.shared.push(alert)
         }
     }
     
@@ -268,5 +317,12 @@ extension ShoesDetailViewModel {
                 ))
             }
         }
+    }
+}
+
+
+private extension String {
+    var trimmed: String {
+        trimmingCharacters(in: .whitespacesAndNewlines)
     }
 }

--- a/Run Mile/Presentation/1.Shoes/Models/ShoeCatalog.swift
+++ b/Run Mile/Presentation/1.Shoes/Models/ShoeCatalog.swift
@@ -1,0 +1,112 @@
+//
+//  ShoeCatalog.swift
+//  Run Mile
+//
+//  Created by Codex on 5/8/26.
+//
+
+import Foundation
+
+
+enum ShoeCatalog {
+    static let other = "기타"
+    static let defaultBrand = "Nike"
+    static let defaultModel = "Alphafly 3"
+    
+    static let brands: [String: [String]] = [
+        "Nike": ["Alphafly 3", "Vaporfly 3", "Pegasus 41", "Invite Run 3", other],
+        "Adidas": ["Adizero Adios Pro 3", "Adizero Takumi Sen 10", "Ultraboost Light", other],
+        "New Balance": ["FuelCell SuperComp Elite v4", "Fresh Foam X 1080v13", other],
+        "Hoka": ["Clifton 9", "Bondi 8", "Mach 6", "Rocket X 2", other],
+        "Saucony": ["Endorphin Pro 4", "Endorphin Speed 4", "Ride 17", other],
+        "Asics": ["Metaspeed Sky Paris", "Metaspeed Edge Paris", "Novablast 4", "Gel-Nimbus 26", other],
+        "Mizuno": ["Wave Rebellion Pro 2", "Wave Rider 27", other],
+        "Brooks": ["Ghost 15", "Glycerin 21", "Hyperion Elite 4", other],
+        other: []
+    ]
+    
+    static var brandList: [String] {
+        brands.keys.sorted().filter { $0 != other } + [other]
+    }
+    
+    static func modelList(for brand: String) -> [String] {
+        brands[brand] ?? []
+    }
+    
+    static func defaultModel(for brand: String) -> String {
+        modelList(for: brand).first ?? ""
+    }
+    
+    /// 선택된 브랜드/모델과 직접 입력값을 실제 저장할 신발 이름으로 변환합니다.
+    static func shoesName(
+        selectedBrand: String,
+        selectedModel: String,
+        customBrand: String,
+        customModel: String
+    ) -> String {
+        let brand = selectedBrand == other ? customBrand.trimmed : selectedBrand
+        let model = selectedBrand == other || selectedModel == other ? customModel.trimmed : selectedModel
+        
+        return [brand, model]
+            .filter { !$0.isEmpty }
+            .joined(separator: " ")
+    }
+    
+    /// 저장된 신발 이름을 브랜드/모델 선택 상태로 복원합니다.
+    static func selection(for shoesName: String) -> ShoeCatalogSelection {
+        let trimmedName = shoesName.trimmed
+        
+        for brand in knownBrandsByLength {
+            guard trimmedName == brand || trimmedName.hasPrefix("\(brand) ") else { continue }
+            
+            let model = trimmedName == brand
+            ? ""
+            : String(trimmedName.dropFirst(brand.count)).trimmed
+            
+            if modelList(for: brand).contains(model) {
+                return ShoeCatalogSelection(
+                    selectedBrand: brand,
+                    selectedModel: model,
+                    customBrand: "",
+                    customModel: ""
+                )
+            }
+            
+            return ShoeCatalogSelection(
+                selectedBrand: brand,
+                selectedModel: other,
+                customBrand: "",
+                customModel: model
+            )
+        }
+        
+        let components = trimmedName.split(separator: " ", maxSplits: 1).map(String.init)
+        return ShoeCatalogSelection(
+            selectedBrand: other,
+            selectedModel: "",
+            customBrand: components.first ?? "",
+            customModel: components.dropFirst().first ?? ""
+        )
+    }
+    
+    private static var knownBrandsByLength: [String] {
+        brandList
+            .filter { $0 != other }
+            .sorted { $0.count > $1.count }
+    }
+}
+
+
+struct ShoeCatalogSelection {
+    let selectedBrand: String
+    let selectedModel: String
+    let customBrand: String
+    let customModel: String
+}
+
+
+private extension String {
+    var trimmed: String {
+        trimmingCharacters(in: .whitespacesAndNewlines)
+    }
+}


### PR DESCRIPTION
close #70

## Summary
이 PR은 신발 상세 뷰에서 신발 정보를 더 직접적으로 관리할 수 있도록 화면 구조를 정리하고, 수정/삭제/운동 관리 흐름을 추가했습니다. 기존 `ShoesDetailView`에 집중되어 있던 UI를 header, mileage card, workout history, management section, sheet 컴포넌트로 분리해 유지보수성을 높였습니다.

## Key Changes

### 1. Shoes Detail View Component Refactoring
- `ShoesDetailHeaderView`, `ShoesDetailMileageCardView`, `ShoesDetailWorkoutHistoryView`, `ShoesDetailManagementSection`을 추가해 신발 상세 화면을 역할별 컴포넌트로 분리했습니다.
- 기존 `ShoesDetailView`의 비대한 UI 구성을 정리하고, 각 섹션이 담당하는 정보와 액션이 더 명확히 드러나도록 수정했습니다.
- `ShoesDetailViewModel`을 상세 관리 흐름에 맞게 정리했습니다.

### 2. Shoes Edit & Delete Flow
- `ShoesEditSheetView`를 추가해 신발 상세 화면에서 신발 정보를 수정할 수 있는 sheet 흐름을 구성했습니다.
- `ShoesDeleteSheetView`를 추가해 신발 삭제 전 확인 과정을 제공하도록 했습니다.
- `ShoesDataRepositoryImpl`과 AddShoes 관련 View/ViewModel 일부를 수정해 신발 정보 관리 흐름과 맞도록 보강했습니다.

### 3. Registered Workout Management
- `ShoesWorkoutManagementSheet`를 추가해 신발에 등록된 운동 기록을 관리할 수 있는 기반을 마련했습니다.
- 신발 상세 화면의 운동 기록 섹션을 별도 컴포넌트로 분리해, 연결된 운동 목록과 관리 액션을 확장하기 쉽게 정리했습니다.

### 4. Shoe Catalog Model
- `ShoeCatalog`를 추가해 신발 브랜드/모델 선택에 필요한 카탈로그 데이터를 분리했습니다.
- 신발 추가 및 수정 흐름에서 사용할 수 있는 공통 신발 데이터 기반을 마련했습니다.

## Impact
- 사용자는 신발 상세 화면에서 신발 정보를 수정하고 삭제할 수 있는 관리 흐름을 사용할 수 있습니다.
- 신발에 연결된 운동 기록 관리 기능을 확장하기 쉬운 구조가 됩니다.
- 상세 화면 UI가 컴포넌트 단위로 분리되어 이후 기능 추가와 디자인 수정이 쉬워집니다.

## Validation
- 변경 사항은 커밋 기록과 `origin/develop...HEAD` diff 기준으로 확인했습니다.
- 로컬 빌드/테스트는 별도로 실행하지 않았습니다.