### PR TITLE
[Feat] HOF 피쳐 고도화

### DIFF
--- a/Run Mile/App/Core/AppDIContainer.swift
+++ b/Run Mile/App/Core/AppDIContainer.swift
@@ -13,15 +13,18 @@ final class AppDIContainer: ScreenDependencyProviding {
     
     private let workoutRepository: WorkoutDataRepository
     private let shoesRepository: ShoesDataRepository
+    private let distanceRecordCacheRepository: WorkoutDistanceRecordCacheRepository
     private let healthBackgroundSyncService: HealthBackgroundSyncService
     
     init(
         workoutRepository: WorkoutDataRepository = WorkoutDataRepositoryImpl(),
         shoesRepository: ShoesDataRepository = ShoesDataRepositoryImpl(),
+        distanceRecordCacheRepository: WorkoutDistanceRecordCacheRepository = WorkoutDistanceRecordCacheRepositoryImpl(),
         healthBackgroundSyncService: HealthBackgroundSyncService? = nil
     ) {
         self.workoutRepository = workoutRepository
         self.shoesRepository = shoesRepository
+        self.distanceRecordCacheRepository = distanceRecordCacheRepository
         self.healthBackgroundSyncService = healthBackgroundSyncService
         ?? DefaultHealthBackgroundSyncService(shoesRepository: shoesRepository)
     }
@@ -111,7 +114,21 @@ final class AppDIContainer: ScreenDependencyProviding {
     func makeHOFViewModel() -> HOFViewModel {
         HOFViewModel(
             useCase: DefaultHOFUseCase(
-                repository: shoesRepository
+                repository: shoesRepository,
+                workoutRepository: workoutRepository,
+                distanceRecordCacheRepository: distanceRecordCacheRepository
+            )
+        )
+    }
+    
+    /// 졸업 신발의 리포트 표시 데이터를 관리하는 ViewModel을 생성합니다.
+    func makeHOFReportViewModel(shoes: Shoes) -> HOFReportViewModel {
+        HOFReportViewModel(
+            shoes: shoes,
+            useCase: DefaultHOFUseCase(
+                repository: shoesRepository,
+                workoutRepository: workoutRepository,
+                distanceRecordCacheRepository: distanceRecordCacheRepository
             )
         )
     }

--- a/Run Mile/App/Core/Preview/PreviewDIContainer.swift
+++ b/Run Mile/App/Core/Preview/PreviewDIContainer.swift
@@ -101,6 +101,11 @@ final class PreviewDIContainer: ScreenDependencyProviding {
         return viewModel
     }
     
+    /// 졸업 리포트 Preview용 ViewModel을 샘플 신발 데이터로 생성합니다.
+    func makeHOFReportViewModel(shoes: Shoes) -> HOFReportViewModel {
+        HOFReportViewModel(shoes: shoes, useCase: PreviewHOFUseCase())
+    }
+    
     /// 개발자 정보 Preview용 ViewModel을 생성합니다.
     func makeInformationViewModel() -> InformationViewModel {
         InformationViewModel()

--- a/Run Mile/App/Core/Preview/PreviewMyPageUseCases.swift
+++ b/Run Mile/App/Core/Preview/PreviewMyPageUseCases.swift
@@ -22,5 +22,34 @@ struct PreviewHOFUseCase: HOFUseCase {
     func fetchShoes() async throws -> [Shoes] {
         PreviewShoesMockData.hallOfFameShoes
     }
+    
+    /// Preview에서 앱 전체 PB 비교에 사용할 러닝 샘플을 반환합니다.
+    func fetchAllRunningWorkouts() async throws -> [Workout] {
+        PreviewShoesMockData.workouts
+    }
+    
+    /// Preview에서는 HealthKit 상세 샘플 대신 샘플 운동의 평균 페이스로 시각 확인용 기록을 구성합니다.
+    func fetchDistanceRecords(for workouts: [Workout]) async -> [WorkoutDistanceRecord] {
+        workouts.flatMap { workout in
+            WorkoutDistanceRecordTarget.allCases.compactMap { target in
+                guard workout.distance >= target.meters,
+                      workout.distance > 0,
+                      workout.time > 0 else {
+                    return nil
+                }
+                
+                let duration = workout.time * target.meters / workout.distance
+                return WorkoutDistanceRecord(
+                    workoutID: workout.id,
+                    target: target,
+                    duration: duration,
+                    workoutDate: workout.date,
+                    segmentStartDate: workout.workout.startDate,
+                    segmentEndDate: workout.workout.startDate.addingTimeInterval(duration),
+                    sourceWorkoutDistance: workout.distance
+                )
+            }
+        }
+    }
 }
 #endif

--- a/Run Mile/App/Core/ScreenDependencyProviding.swift
+++ b/Run Mile/App/Core/ScreenDependencyProviding.swift
@@ -18,5 +18,6 @@ protocol ScreenDependencyProviding {
     func makeAutoMileageShoesViewModel() -> AutoMileageShoesViewModel
     func makeMyPageViewModel() -> MyPageViewModel
     func makeHOFViewModel() -> HOFViewModel
+    func makeHOFReportViewModel(shoes: Shoes) -> HOFReportViewModel
     func makeInformationViewModel() -> InformationViewModel
 }

--- a/Run Mile/App/Core/ScreenFactory.swift
+++ b/Run Mile/App/Core/ScreenFactory.swift
@@ -35,6 +35,8 @@ struct ScreenFactory {
             FitnessConnectView()
         case .hof:
             HOFView(viewModel: container.makeHOFViewModel())
+        case let .hofReport(shoes):
+            HOFReportView(viewModel: container.makeHOFReportViewModel(shoes: shoes))
         case .info:
             InformationView(viewModel: container.makeInformationViewModel())
         case let .imageDetail(image):

--- a/Run Mile/Data/HOF/WorkoutDistanceRecordCacheRepositoryImpl.swift
+++ b/Run Mile/Data/HOF/WorkoutDistanceRecordCacheRepositoryImpl.swift
@@ -1,0 +1,85 @@
+//
+//  WorkoutDistanceRecordCacheRepositoryImpl.swift
+//  Run Mile
+//
+//  Created by Codex on 5/17/26.
+//
+
+import Foundation
+
+
+actor WorkoutDistanceRecordCacheRepositoryImpl: WorkoutDistanceRecordCacheRepository {
+    private let cacheKey = "hofWorkoutDistanceRecordCache.v2"
+    private let maxCacheCount = 1_000
+    
+    /// 운동 ID와 운동 메타데이터가 일치하는 캐시만 반환합니다.
+    func fetchRecords(for workout: Workout) async -> [WorkoutDistanceRecord]? {
+        let store = loadStore()
+        guard let entry = store[workout.id.uuidString],
+              entry.matches(workout: workout) else {
+            return nil
+        }
+        
+        return entry.records
+    }
+    
+    /// 거리별 PB 계산 결과를 운동 ID 기준으로 저장해 추후 PB 카드와 운동 상세 연결에 사용합니다.
+    func saveRecords(_ records: [WorkoutDistanceRecord], for workout: Workout) async {
+        var store = loadStore()
+        store[workout.id.uuidString] = CachedWorkoutDistanceRecordEntry(
+            workoutID: workout.id,
+            workoutStartDate: workout.workout.startDate,
+            workoutEndDate: workout.workout.endDate,
+            workoutDuration: workout.time,
+            workoutDistance: workout.distance,
+            cachedAt: Date(),
+            records: records
+        )
+        
+        if store.count > maxCacheCount {
+            store = Dictionary(
+                uniqueKeysWithValues: store
+                    .sorted { $0.value.cachedAt > $1.value.cachedAt }
+                    .prefix(maxCacheCount)
+                    .map { ($0.key, $0.value) }
+            )
+        }
+        
+        saveStore(store)
+    }
+    
+    private func loadStore() -> [String: CachedWorkoutDistanceRecordEntry] {
+        guard let data = UserDefaults.standard.data(forKey: cacheKey) else {
+            return [:]
+        }
+        
+        return (try? JSONDecoder().decode([String: CachedWorkoutDistanceRecordEntry].self, from: data)) ?? [:]
+    }
+    
+    private func saveStore(_ store: [String: CachedWorkoutDistanceRecordEntry]) {
+        guard let data = try? JSONEncoder().encode(store) else {
+            return
+        }
+        
+        UserDefaults.standard.set(data, forKey: cacheKey)
+    }
+}
+
+
+private struct CachedWorkoutDistanceRecordEntry: Codable {
+    let workoutID: UUID
+    let workoutStartDate: Date
+    let workoutEndDate: Date
+    let workoutDuration: TimeInterval
+    let workoutDistance: Double
+    let cachedAt: Date
+    let records: [WorkoutDistanceRecord]
+    
+    func matches(workout: Workout) -> Bool {
+        workoutID == workout.id
+        && abs(workoutStartDate.timeIntervalSince(workout.workout.startDate)) < 1
+        && abs(workoutEndDate.timeIntervalSince(workout.workout.endDate)) < 1
+        && abs(workoutDuration - workout.time) < 1
+        && abs(workoutDistance - workout.distance) < 1
+    }
+}

--- a/Run Mile/Data/Health/WorkoutDataRepositoryImpl.swift
+++ b/Run Mile/Data/Health/WorkoutDataRepositoryImpl.swift
@@ -220,8 +220,7 @@ actor WorkoutDataRepositoryImpl: WorkoutDataRepository {
         return try await DTOMapper.CDWorkoutDTOtoEntities(fetchedResults)
     }
     
-    public func fetchSplits(workout: HKWorkout) async throws -> [SplitInfo] {
-        // 1. 거리 데이터 가져오기 (시간순 정렬 필수)
+    public func fetchDistanceSamples(workout: HKWorkout) async throws -> [WorkoutDistanceSample] {
         let distanceType = HKQuantityType.quantityType(forIdentifier: .distanceWalkingRunning)!
         let predicate = HKQuery.predicateForObjects(from: workout)
         let sortDescriptor = NSSortDescriptor(key: HKSampleSortIdentifierStartDate, ascending: true)
@@ -233,6 +232,57 @@ actor WorkoutDataRepositoryImpl: WorkoutDataRepository {
             sortDescriptors: [sortDescriptor]
         )
         
+        var result: [WorkoutDistanceSample] = []
+        
+        for sample in samples {
+            if sample.count > 1 {
+                let seriesSamples = try await fetchQuantitySeriesDistanceSamples(sample: sample, type: distanceType)
+                result.append(contentsOf: seriesSamples)
+            } else {
+                let distance = sample.quantity.doubleValue(for: .meter())
+                guard distance > 0 else { continue }
+                
+                result.append(
+                    WorkoutDistanceSample(
+                        startDate: sample.startDate,
+                        endDate: sample.endDate,
+                        distance: distance
+                    )
+                )
+            }
+        }
+        
+        return result.compactMap { sample in
+            let startDate = sample.startDate < workout.startDate ? workout.startDate : sample.startDate
+            let endDate = sample.endDate > workout.endDate ? workout.endDate : sample.endDate
+            
+            guard endDate > startDate else { return nil }
+            
+            let originalDuration = sample.endDate.timeIntervalSince(sample.startDate)
+            let overlapDuration = endDate.timeIntervalSince(startDate)
+            let distance: Double
+            
+            if originalDuration > 0 {
+                distance = sample.distance * min(overlapDuration / originalDuration, 1)
+            } else {
+                distance = sample.distance
+            }
+            
+            guard distance > 0 else { return nil }
+            
+            return WorkoutDistanceSample(
+                startDate: startDate,
+                endDate: endDate,
+                distance: distance
+            )
+        }
+        .sorted { $0.startDate < $1.startDate }
+    }
+    
+    public func fetchSplits(workout: HKWorkout) async throws -> [SplitInfo] {
+        // 1. 거리 데이터 가져오기 (시간순 정렬 필수)
+        let samples = try await fetchDistanceSamples(workout: workout)
+        
         // 2. 일시정지 구간(Pause Intervals) 미리 계산
         let pauseIntervals = getPauseIntervals(workout: workout)
         
@@ -243,7 +293,7 @@ actor WorkoutDataRepositoryImpl: WorkoutDataRepository {
         
         // 3. 샘플 순회
         for sample in samples {
-            let sampleDistance = sample.quantity.doubleValue(for: .meter())
+            let sampleDistance = sample.distance
             let startDistance = accumulatedDistance
             let endDistance = accumulatedDistance + sampleDistance
             
@@ -320,7 +370,10 @@ actor WorkoutDataRepositoryImpl: WorkoutDataRepository {
             if event.type == .pause {
                 pauseStart = event.dateInterval.start
             } else if event.type == .resume, let start = pauseStart {
-                pauses.append(DateInterval(start: start, end: event.dateInterval.start))
+                let end = event.dateInterval.start
+                if end > start {
+                    pauses.append(DateInterval(start: start, end: end))
+                }
                 pauseStart = nil
             }
         }
@@ -329,6 +382,8 @@ actor WorkoutDataRepositoryImpl: WorkoutDataRepository {
     
     /// 시작~종료 시간 사이에서 일시정지 시간을 뺀 '순수 운동 시간' 계산
     private func calculateActiveDuration(start: Date, end: Date, pauses: [DateInterval]) -> TimeInterval {
+        guard end > start else { return 0 }
+        
         var duration = end.timeIntervalSince(start)
         let totalRange = DateInterval(start: start, end: end)
         
@@ -340,6 +395,41 @@ actor WorkoutDataRepositoryImpl: WorkoutDataRepository {
         }
         
         return max(duration, 0)
+    }
+    
+    private func fetchQuantitySeriesDistanceSamples(sample: HKQuantitySample, type: HKQuantityType) async throws -> [WorkoutDistanceSample] {
+        let predicate = HKQuery.predicateForObject(with: sample.uuid)
+        
+        return try await withCheckedThrowingContinuation { continuation in
+            var samples: [WorkoutDistanceSample] = []
+            
+            let query = HKQuantitySeriesSampleQuery(quantityType: type, predicate: predicate) { _, quantity, dateInterval, _, done, error in
+                if let error {
+                    continuation.resume(throwing: error)
+                    return
+                }
+                
+                if let quantity,
+                   let dateInterval {
+                    let distance = quantity.doubleValue(for: .meter())
+                    if distance > 0 {
+                        samples.append(
+                            WorkoutDistanceSample(
+                                startDate: dateInterval.start,
+                                endDate: dateInterval.end,
+                                distance: distance
+                            )
+                        )
+                    }
+                }
+                
+                if done {
+                    continuation.resume(returning: samples)
+                }
+            }
+            
+            store.execute(query)
+        }
     }
     
     private func fetchQuantitySeriesPoints(sample: HKQuantitySample, type: HKQuantityType) async throws -> [RunningMetricPoint] {

--- a/Run Mile/Domain/Entities/WorkoutDistanceRecord.swift
+++ b/Run Mile/Domain/Entities/WorkoutDistanceRecord.swift
@@ -1,0 +1,79 @@
+//
+//  WorkoutDistanceRecord.swift
+//  Run Mile
+//
+//  Created by Codex on 5/17/26.
+//
+
+import Foundation
+
+
+enum WorkoutDistanceRecordTarget: String, CaseIterable, Codable, Identifiable, Sendable, Hashable {
+    case fiveK
+    case tenK
+    case halfMarathon
+    case marathon
+    
+    var id: String { rawValue }
+    
+    var title: String {
+        switch self {
+        case .fiveK:
+            return "5K"
+        case .tenK:
+            return "10K"
+        case .halfMarathon:
+            return "Half"
+        case .marathon:
+            return "Full"
+        }
+    }
+    
+    var meters: Double {
+        switch self {
+        case .fiveK:
+            return 5_000
+        case .tenK:
+            return 10_000
+        case .halfMarathon:
+            return 21_097.5
+        case .marathon:
+            return 42_195
+        }
+    }
+    
+    var unavailableText: String {
+        switch self {
+        case .fiveK:
+            return "5km 이상 러닝 없음"
+        case .tenK:
+            return "10km 이상 러닝 없음"
+        case .halfMarathon:
+            return "하프 이상 러닝 없음"
+        case .marathon:
+            return "풀코스 기록 없음"
+        }
+    }
+}
+
+
+struct WorkoutDistanceRecord: Codable, Identifiable, Sendable, Hashable {
+    let workoutID: UUID
+    let target: WorkoutDistanceRecordTarget
+    let duration: TimeInterval
+    let workoutDate: Date
+    let segmentStartDate: Date
+    let segmentEndDate: Date
+    let sourceWorkoutDistance: Double
+    
+    var id: String {
+        "\(workoutID.uuidString)-\(target.rawValue)"
+    }
+}
+
+
+struct WorkoutDistanceSample: Sendable {
+    let startDate: Date
+    let endDate: Date
+    let distance: Double
+}

--- a/Run Mile/Domain/Interfaces/Repositories/WorkoutDataRepository.swift
+++ b/Run Mile/Domain/Interfaces/Repositories/WorkoutDataRepository.swift
@@ -25,6 +25,9 @@ protocol WorkoutDataRepository: Sendable {
     /// (내부 메소드)
     func fetchSplits(workout: HKWorkout) async throws -> [SplitInfo]
     
+    /// 거리별 PB 계산에 사용할 거리 샘플을 시간순으로 불러옵니다.
+    func fetchDistanceSamples(workout: HKWorkout) async throws -> [WorkoutDistanceSample]
+    
     /// 단일 운동의 운동 경로 데이터를 불러옵니다.
     func fetchDetailedWorkoutRouteData(workout: HKWorkout) async throws -> [CLLocation]
     

--- a/Run Mile/Domain/Interfaces/Repositories/WorkoutDistanceRecordCacheRepository.swift
+++ b/Run Mile/Domain/Interfaces/Repositories/WorkoutDistanceRecordCacheRepository.swift
@@ -1,0 +1,14 @@
+//
+//  WorkoutDistanceRecordCacheRepository.swift
+//  Run Mile
+//
+//  Created by Codex on 5/17/26.
+//
+
+import Foundation
+
+
+protocol WorkoutDistanceRecordCacheRepository: Sendable {
+    func fetchRecords(for workout: Workout) async -> [WorkoutDistanceRecord]?
+    func saveRecords(_ records: [WorkoutDistanceRecord], for workout: Workout) async
+}

--- a/Run Mile/Domain/UseCases/HOFUseCase.swift
+++ b/Run Mile/Domain/UseCases/HOFUseCase.swift
@@ -6,21 +6,316 @@
 //
 
 import Foundation
+import HealthKit
 
 
 protocol HOFUseCase: Sendable {
     func fetchShoes() async throws -> [Shoes]
+    func fetchAllRunningWorkouts() async throws -> [Workout]
+    func fetchDistanceRecords(for workouts: [Workout]) async -> [WorkoutDistanceRecord]
 }
 
 
 final class DefaultHOFUseCase: HOFUseCase {
     private let repository: ShoesDataRepository
+    private let workoutRepository: WorkoutDataRepository
+    private let distanceRecordCacheRepository: WorkoutDistanceRecordCacheRepository
     
-    init(repository: ShoesDataRepository) {
+    init(
+        repository: ShoesDataRepository,
+        workoutRepository: WorkoutDataRepository,
+        distanceRecordCacheRepository: WorkoutDistanceRecordCacheRepository
+    ) {
         self.repository = repository
+        self.workoutRepository = workoutRepository
+        self.distanceRecordCacheRepository = distanceRecordCacheRepository
     }
     
     func fetchShoes() async throws -> [Shoes] {
         try await repository.fetchHOFShoes()
+    }
+    
+    func fetchAllRunningWorkouts() async throws -> [Workout] {
+        try await workoutRepository.fetchAllWorkoutData()
+    }
+    
+    func fetchDistanceRecords(for workouts: [Workout]) async -> [WorkoutDistanceRecord] {
+        var records: [WorkoutDistanceRecord] = []
+        
+        for workout in recordEligibleWorkouts(workouts) {
+            if let cachedRecords = await distanceRecordCacheRepository.fetchRecords(for: workout) {
+                records.append(contentsOf: cachedRecords)
+                continue
+            }
+            
+            do {
+                let samples = try await workoutRepository.fetchDistanceSamples(workout: workout.workout)
+                let calculatedRecords = makeDistanceRecords(workout: workout, samples: samples)
+                await distanceRecordCacheRepository.saveRecords(calculatedRecords, for: workout)
+                records.append(contentsOf: calculatedRecords)
+            } catch {
+                #if DEBUG
+                print("[HOFReport] distance record skipped: \(workout.id), error: \(error.localizedDescription)")
+                #endif
+            }
+        }
+        
+        return records
+    }
+}
+
+
+private extension DefaultHOFUseCase {
+    struct DistanceRecordSegment {
+        let startDistance: Double
+        let endDistance: Double
+        let startActiveDuration: TimeInterval
+        let endActiveDuration: TimeInterval
+        let startDate: Date
+        let endDate: Date
+    }
+    
+    struct DistanceRecordPoint {
+        let activeDuration: TimeInterval
+        let date: Date
+    }
+    
+    func makeDistanceRecords(workout: Workout, samples: [WorkoutDistanceSample]) -> [WorkoutDistanceRecord] {
+        let segments = makeDistanceSegments(workout: workout, samples: samples)
+        
+        return WorkoutDistanceRecordTarget.allCases.compactMap { target in
+            bestRecord(for: target, workout: workout, segments: segments)
+        }
+    }
+    
+    func makeDistanceSegments(workout: Workout, samples: [WorkoutDistanceSample]) -> [DistanceRecordSegment] {
+        let pauseIntervals = pauseIntervals(for: workout.workout)
+        var accumulatedDistance = 0.0
+        var segments: [DistanceRecordSegment] = []
+        
+        for sample in samples.sorted(by: { $0.startDate < $1.startDate }) {
+            let sampleStartDate = sample.startDate < workout.workout.startDate ? workout.workout.startDate : sample.startDate
+            let sampleEndDate = sample.endDate > workout.workout.endDate ? workout.workout.endDate : sample.endDate
+            
+            guard sample.distance > 0,
+                  sampleEndDate > sampleStartDate else {
+                continue
+            }
+            
+            let originalDuration = sample.endDate.timeIntervalSince(sample.startDate)
+            let overlapDuration = sampleEndDate.timeIntervalSince(sampleStartDate)
+            let adjustedDistance: Double
+            
+            if originalDuration > 0 {
+                adjustedDistance = sample.distance * min(overlapDuration / originalDuration, 1)
+            } else {
+                adjustedDistance = sample.distance
+            }
+            
+            guard adjustedDistance > 0 else { continue }
+            
+            let startActiveDuration = activeDuration(
+                from: workout.workout.startDate,
+                to: sampleStartDate,
+                pauses: pauseIntervals
+            )
+            let endActiveDuration = activeDuration(
+                from: workout.workout.startDate,
+                to: sampleEndDate,
+                pauses: pauseIntervals
+            )
+            
+            guard endActiveDuration > startActiveDuration else {
+                continue
+            }
+            
+            let startDistance = accumulatedDistance
+            let endDistance = accumulatedDistance + adjustedDistance
+            
+            segments.append(
+                DistanceRecordSegment(
+                    startDistance: startDistance,
+                    endDistance: endDistance,
+                    startActiveDuration: startActiveDuration,
+                    endActiveDuration: endActiveDuration,
+                    startDate: sampleStartDate,
+                    endDate: sampleEndDate
+                )
+            )
+            
+            accumulatedDistance = endDistance
+        }
+        
+        return segments
+    }
+    
+    func bestRecord(
+        for target: WorkoutDistanceRecordTarget,
+        workout: Workout,
+        segments: [DistanceRecordSegment]
+    ) -> WorkoutDistanceRecord? {
+        guard let totalDistance = segments.last?.endDistance,
+              totalDistance >= target.meters else {
+            return nil
+        }
+        
+        var bestRecord: WorkoutDistanceRecord?
+        let startDistances = candidateStartDistances(
+            for: target.meters,
+            totalDistance: totalDistance,
+            segments: segments
+        )
+        
+        for startDistance in startDistances {
+            let endDistance = startDistance + target.meters
+            guard let startPoint = point(at: startDistance, in: segments),
+                  let endPoint = point(at: endDistance, in: segments) else {
+                continue
+            }
+            
+            let duration = endPoint.activeDuration - startPoint.activeDuration
+            guard duration > 0, duration.isFinite else { continue }
+            
+            let candidate = WorkoutDistanceRecord(
+                workoutID: workout.id,
+                target: target,
+                duration: duration,
+                workoutDate: workout.date,
+                segmentStartDate: startPoint.date,
+                segmentEndDate: endPoint.date,
+                sourceWorkoutDistance: workout.distance
+            )
+            
+            if let currentBest = bestRecord {
+                if candidate.duration < currentBest.duration {
+                    bestRecord = candidate
+                }
+            } else {
+                bestRecord = candidate
+            }
+        }
+        
+        return bestRecord
+    }
+    
+    /// 시작점 또는 종료점이 샘플 경계에 걸리는 후보를 모두 만들어 최고 구간 누락을 줄입니다.
+    func candidateStartDistances(
+        for targetDistance: Double,
+        totalDistance: Double,
+        segments: [DistanceRecordSegment]
+    ) -> [Double] {
+        var startDistances: [Double] = []
+        
+        for segment in segments {
+            if segment.startDistance + targetDistance <= totalDistance {
+                startDistances.append(segment.startDistance)
+            }
+            
+            let startDistanceForSegmentEnd = segment.endDistance - targetDistance
+            if startDistanceForSegmentEnd >= 0,
+               startDistanceForSegmentEnd + targetDistance <= totalDistance {
+                startDistances.append(startDistanceForSegmentEnd)
+            }
+        }
+        
+        return startDistances
+    }
+    
+    /// 누적 거리 지점이 포함된 샘플 구간을 이진 탐색으로 찾아 시간 좌표를 보간합니다.
+    func point(at distance: Double, in segments: [DistanceRecordSegment]) -> DistanceRecordPoint? {
+        guard let firstSegment = segments.first,
+              let lastSegment = segments.last,
+              distance >= firstSegment.startDistance,
+              distance <= lastSegment.endDistance else {
+            return nil
+        }
+        
+        var lowerBound = 0
+        var upperBound = segments.count - 1
+        
+        while lowerBound < upperBound {
+            let middle = (lowerBound + upperBound) / 2
+            
+            if segments[middle].endDistance < distance {
+                lowerBound = middle + 1
+            } else {
+                upperBound = middle
+            }
+        }
+        
+        let segment = segments[lowerBound]
+        guard distance >= segment.startDistance,
+              distance <= segment.endDistance else {
+            return nil
+        }
+        
+        let distanceDelta = segment.endDistance - segment.startDistance
+        guard distanceDelta > 0 else {
+            return nil
+        }
+        
+        let progress = (distance - segment.startDistance) / distanceDelta
+        let activeDuration = segment.startActiveDuration
+        + (segment.endActiveDuration - segment.startActiveDuration) * progress
+        let timestamp = segment.startDate.addingTimeInterval(
+            segment.endDate.timeIntervalSince(segment.startDate) * progress
+        )
+        
+        return DistanceRecordPoint(activeDuration: activeDuration, date: timestamp)
+    }
+    
+    func pauseIntervals(for workout: HKWorkout) -> [DateInterval] {
+        guard let events = workout.workoutEvents else { return [] }
+        var pauses: [DateInterval] = []
+        var pauseStart: Date?
+        
+        for event in events {
+            if event.type == .pause {
+                pauseStart = event.dateInterval.start
+            } else if event.type == .resume, let start = pauseStart {
+                let end = event.dateInterval.start
+                if end > start {
+                    pauses.append(DateInterval(start: start, end: end))
+                }
+                pauseStart = nil
+            }
+        }
+        
+        return pauses
+    }
+    
+    func activeDuration(from start: Date, to end: Date, pauses: [DateInterval]) -> TimeInterval {
+        guard end > start else { return 0 }
+        
+        var duration = end.timeIntervalSince(start)
+        let totalRange = DateInterval(start: start, end: end)
+        
+        for pause in pauses {
+            if let intersection = totalRange.intersection(with: pause) {
+                duration -= intersection.duration
+            }
+        }
+        
+        return max(duration, 0)
+    }
+    
+    func uniqueWorkouts(_ workouts: [Workout]) -> [Workout] {
+        var seenIDs: Set<UUID> = []
+        var result: [Workout] = []
+        
+        for workout in workouts where !seenIDs.contains(workout.id) {
+            seenIDs.insert(workout.id)
+            result.append(workout)
+        }
+        
+        return result
+    }
+    
+    func recordEligibleWorkouts(_ workouts: [Workout]) -> [Workout] {
+        let minimumTargetDistance = WorkoutDistanceRecordTarget.allCases
+            .map(\.meters)
+            .min() ?? 0
+        
+        return uniqueWorkouts(workouts).filter { $0.distance >= minimumTargetDistance }
     }
 }

--- a/Run Mile/Presentation/0.Main/NavigationCoordinator.swift
+++ b/Run Mile/Presentation/0.Main/NavigationCoordinator.swift
@@ -118,6 +118,7 @@ extension NavigationCoordinator {
         case myPage
         case fitnessConnect
         case hof
+        case hofReport(Shoes)
         case info
         
         case imageDetail(Data)

--- a/Run Mile/Presentation/3.MyPage/3-1.HallOfFame/Components/HOFReportComponents.swift
+++ b/Run Mile/Presentation/3.MyPage/3-1.HallOfFame/Components/HOFReportComponents.swift
@@ -1,0 +1,232 @@
+//
+//  HOFReportComponents.swift
+//  Run Mile
+//
+//  Created by Codex on 5/17/26.
+//
+
+import SwiftUI
+
+
+struct HOFReportSection<Content: View>: View {
+    let title: String
+    let icon: String
+    @ViewBuilder let content: Content
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 14) {
+            Label(title, systemImage: icon)
+                .font(.title3)
+                .fontWeight(.black)
+                .foregroundStyle(RunMileColor.foreground)
+
+            content
+        }
+        .padding(20)
+        .runMileBrutalCard()
+        .padding(.horizontal)
+    }
+}
+
+
+struct HOFReportStatTile: View {
+    let title: String
+    let value: String
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 6) {
+            Text(title)
+                .font(.caption)
+                .fontWeight(.black)
+                .foregroundStyle(RunMileColor.mutedForeground)
+
+            Text(value)
+                .font(.headline)
+                .fontWeight(.black)
+                .foregroundStyle(RunMileColor.foreground)
+                .lineLimit(1)
+                .minimumScaleFactor(0.72)
+        }
+        .padding(12)
+        .frame(maxWidth: .infinity, alignment: .leading)
+        .background(RunMileColor.muted, in: RoundedRectangle(cornerRadius: RunMileRadius.card, style: .continuous))
+        .overlay {
+            RoundedRectangle(cornerRadius: RunMileRadius.card, style: .continuous)
+                .stroke(RunMileColor.border, lineWidth: RunMileStroke.hairline)
+        }
+    }
+}
+
+
+struct HOFDistanceRecordsBoard: View {
+    let records: [HOFDistanceRecord]
+    
+    private var columns: [GridItem] {
+        [
+            GridItem(.flexible(), spacing: 10),
+            GridItem(.flexible(), spacing: 10)
+        ]
+    }
+    
+    var body: some View {
+        VStack(alignment: .leading, spacing: 12) {
+            HStack(spacing: 8) {
+                Image(systemName: "rosette")
+                    .font(.headline.weight(.black))
+                
+                Text("거리별 최고 기록")
+                    .font(.headline)
+                    .fontWeight(.black)
+                    .foregroundStyle(RunMileColor.foreground)
+                
+                Spacer()
+            }
+            
+            LazyVGrid(columns: columns, spacing: 10) {
+                ForEach(records) { record in
+                    HOFDistanceRecordTile(record: record)
+                }
+            }
+        }
+        .padding(14)
+        .frame(maxWidth: .infinity, alignment: .leading)
+        .background(RunMileColor.muted, in: RoundedRectangle(cornerRadius: RunMileRadius.card, style: .continuous))
+        .overlay {
+            RoundedRectangle(cornerRadius: RunMileRadius.card, style: .continuous)
+                .stroke(RunMileColor.border, lineWidth: RunMileStroke.border)
+        }
+    }
+}
+
+
+struct HOFDistanceRecordTile: View {
+    let record: HOFDistanceRecord
+    
+    var body: some View {
+        VStack(alignment: .leading, spacing: 9) {
+            HStack(spacing: 6) {
+                Text(record.title)
+                    .font(.caption)
+                    .fontWeight(.black)
+                    .foregroundStyle(record.isAvailable ? RunMileColor.primary : RunMileColor.mutedForeground)
+                
+                Spacer(minLength: 4)
+                
+                if record.isPersonalBest {
+                    Text("PB")
+                        .font(.caption2)
+                        .fontWeight(.black)
+                        .foregroundStyle(RunMileColor.secondaryForeground)
+                        .padding(.horizontal, 7)
+                        .padding(.vertical, 4)
+                        .background(RunMileColor.secondary, in: RoundedRectangle(cornerRadius: RunMileRadius.progress, style: .continuous))
+                        .overlay {
+                            RoundedRectangle(cornerRadius: RunMileRadius.progress, style: .continuous)
+                                .stroke(RunMileColor.border, lineWidth: RunMileStroke.hairline)
+                        }
+                }
+            }
+            
+            Text(record.timeText)
+                .font(.title3)
+                .fontWeight(.black)
+                .foregroundStyle(record.isAvailable ? RunMileColor.foreground : RunMileColor.mutedForeground)
+                .lineLimit(1)
+                .minimumScaleFactor(0.78)
+            
+            Text(record.detailText)
+                .font(.caption2)
+                .fontWeight(.semibold)
+                .foregroundStyle(RunMileColor.mutedForeground)
+                .lineLimit(2)
+                .minimumScaleFactor(0.82)
+        }
+        .padding(12)
+        .frame(minHeight: 106, alignment: .topLeading)
+        .frame(maxWidth: .infinity, alignment: .leading)
+        .background(record.isPersonalBest ? RunMileColor.secondary.opacity(0.22) : RunMileColor.card, in: RoundedRectangle(cornerRadius: RunMileRadius.card, style: .continuous))
+        .overlay {
+            RoundedRectangle(cornerRadius: RunMileRadius.card, style: .continuous)
+                .stroke(record.isPersonalBest ? RunMileColor.primary : RunMileColor.border, lineWidth: RunMileStroke.border)
+        }
+    }
+}
+
+
+struct HOFMemorableRunRow: View {
+    let run: HOFMemorableRun
+
+    var body: some View {
+        HStack(spacing: 12) {
+            Image(systemName: run.icon)
+                .font(.headline)
+                .foregroundStyle(run.isPrimary ? RunMileColor.secondaryForeground : RunMileColor.primaryForeground)
+                .frame(width: 38, height: 38)
+                .background(run.isPrimary ? RunMileColor.secondary : RunMileColor.primary, in: RoundedRectangle(cornerRadius: RunMileRadius.small, style: .continuous))
+                .overlay {
+                    RoundedRectangle(cornerRadius: RunMileRadius.small, style: .continuous)
+                        .stroke(RunMileColor.border, lineWidth: RunMileStroke.border)
+                }
+
+            VStack(alignment: .leading, spacing: 4) {
+                Text(run.title)
+                    .font(.subheadline)
+                    .fontWeight(.black)
+                    .foregroundStyle(RunMileColor.foreground)
+
+                Text(run.detail)
+                    .font(.caption)
+                    .fontWeight(.semibold)
+                    .foregroundStyle(RunMileColor.mutedForeground)
+            }
+
+            Spacer()
+        }
+        .padding(12)
+        .background(RunMileColor.card, in: RoundedRectangle(cornerRadius: RunMileRadius.card, style: .continuous))
+        .overlay {
+            RoundedRectangle(cornerRadius: RunMileRadius.card, style: .continuous)
+                .stroke(RunMileColor.border, lineWidth: RunMileStroke.border)
+        }
+    }
+}
+
+
+struct HOFMileageMilestoneRow: View {
+    let milestone: HOFMileageMilestone
+
+    var body: some View {
+        HStack(alignment: .top, spacing: 12) {
+            VStack(spacing: 0) {
+                Circle()
+                    .fill(milestone.isGraduation ? RunMileColor.primary : RunMileColor.secondary)
+                    .frame(width: 18, height: 18)
+                    .overlay {
+                        Circle()
+                            .stroke(RunMileColor.border, lineWidth: RunMileStroke.border)
+                    }
+
+                if !milestone.isGraduation {
+                    Rectangle()
+                        .fill(RunMileColor.border)
+                        .frame(width: 3, height: 36)
+                }
+            }
+
+            VStack(alignment: .leading, spacing: 4) {
+                Text(milestone.title)
+                    .font(.subheadline)
+                    .fontWeight(.black)
+                    .foregroundStyle(RunMileColor.foreground)
+
+                Text(milestone.dateText)
+                    .font(.caption)
+                    .fontWeight(.semibold)
+                    .foregroundStyle(RunMileColor.mutedForeground)
+            }
+            .padding(.bottom, 18)
+
+            Spacer()
+        }
+    }
+}

--- a/Run Mile/Presentation/3.MyPage/3-1.HallOfFame/HOFReportView.swift
+++ b/Run Mile/Presentation/3.MyPage/3-1.HallOfFame/HOFReportView.swift
@@ -1,0 +1,259 @@
+//
+//  HOFReportView.swift
+//  Run Mile
+//
+//  Created by Codex on 5/13/26.
+//
+
+import SwiftUI
+
+
+struct HOFReportView: View {
+    @State private var viewModel: HOFReportViewModel
+
+    init(viewModel: HOFReportViewModel) {
+        self.viewModel = viewModel
+    }
+
+    var body: some View {
+        ScrollView {
+            VStack(spacing: 24) {
+                heroSection
+                // 추후 기능 연결 예정
+                // aiSummarySection
+                careerSummarySection
+                memorableRunsSection
+                mileageJourneySection
+                // graduationMemoSection
+                // shareCardSection
+            }
+            .padding(.vertical, 20)
+        }
+        .background(RunMileColor.background)
+        .navigationTitle("졸업 리포트")
+        .navigationBarTitleDisplayMode(.inline)
+        .toolbarBackground(.hidden, for: .navigationBar)
+        .task {
+            await viewModel.onAppear()
+        }
+    }
+
+    private var heroSection: some View {
+        VStack(spacing: 16) {
+            shoeImage
+
+            VStack(spacing: 8) {
+                Text("LEGENDARY")
+                    .font(.caption)
+                    .fontWeight(.black)
+                    .foregroundStyle(RunMileColor.primary)
+                    .tracking(2)
+
+                Text(viewModel.shoeNickname)
+                    .font(.largeTitle)
+                    .fontWeight(.heavy)
+                    .foregroundStyle(RunMileColor.foreground)
+                    .multilineTextAlignment(.center)
+
+                Text(viewModel.shoeName)
+                    .font(.subheadline)
+                    .fontWeight(.semibold)
+                    .foregroundStyle(RunMileColor.mutedForeground)
+                    .multilineTextAlignment(.center)
+            }
+
+            VStack(spacing: 4) {
+                Text(viewModel.report.totalMileageText)
+                    .font(.system(size: 52, weight: .black))
+                    .foregroundStyle(RunMileColor.foreground)
+                    .minimumScaleFactor(0.7)
+                    .lineLimit(1)
+
+                Text("목표 \(viewModel.goalMileageText)의 \(viewModel.report.achievementRate)%")
+                    .font(.headline)
+                    .fontWeight(.black)
+                    .foregroundStyle(RunMileColor.primary)
+            }
+
+            HStack(spacing: 8) {
+                Image(systemName: "calendar")
+                Text(viewModel.report.dateRangeText)
+            }
+            .font(.caption)
+            .fontWeight(.bold)
+            .foregroundStyle(RunMileColor.mutedForeground)
+
+            Text("\(viewModel.report.activeDays)일 함께 달림")
+                .font(.headline)
+                .fontWeight(.black)
+                .foregroundStyle(RunMileColor.secondaryForeground)
+                .padding(.horizontal, 14)
+                .padding(.vertical, 8)
+                .background(RunMileColor.secondary, in: RoundedRectangle(cornerRadius: RunMileRadius.button, style: .continuous))
+                .overlay {
+                    RoundedRectangle(cornerRadius: RunMileRadius.button, style: .continuous)
+                        .stroke(RunMileColor.border, lineWidth: RunMileStroke.border)
+                }
+        }
+        .padding(24)
+        .frame(maxWidth: .infinity)
+        .runMileBrutalCard()
+        .padding(.horizontal)
+    }
+
+    private var shoeImage: some View {
+        Group {
+            if let uiImage = UIImage(data: viewModel.shoeImageData) {
+                Image(uiImage: uiImage)
+                    .resizable()
+                    .scaledToFit()
+                    .padding(18)
+                    .onTapGesture(perform: viewModel.imageTapped)
+            } else {
+                Image(systemName: "shoe.fill")
+                    .resizable()
+                    .scaledToFit()
+                    .foregroundStyle(RunMileColor.mutedForeground)
+                    .padding(34)
+            }
+        }
+        .frame(width: 170, height: 170)
+        .background(RunMileColor.muted, in: RoundedRectangle(cornerRadius: RunMileRadius.image, style: .continuous))
+        .overlay {
+            RoundedRectangle(cornerRadius: RunMileRadius.image, style: .continuous)
+                .stroke(RunMileColor.border, lineWidth: RunMileStroke.border)
+        }
+        .shadow(color: RunMileColor.border, radius: 0, x: 5, y: 5)
+    }
+
+    private var aiSummarySection: some View {
+        HOFReportSection(title: "AI 리포트", icon: "sparkles") {
+            Text(viewModel.report.aiSummaryText)
+                .font(.subheadline)
+                .fontWeight(.semibold)
+                .foregroundStyle(RunMileColor.secondaryForeground)
+                .fixedSize(horizontal: false, vertical: true)
+                .padding(14)
+                .frame(maxWidth: .infinity, alignment: .leading)
+                .background(RunMileColor.secondary, in: RoundedRectangle(cornerRadius: RunMileRadius.card, style: .continuous))
+                .overlay {
+                    RoundedRectangle(cornerRadius: RunMileRadius.card, style: .continuous)
+                        .stroke(RunMileColor.border, lineWidth: RunMileStroke.border)
+                }
+        }
+    }
+
+    private var careerSummarySection: some View {
+        HOFReportSection(title: "커리어 요약", icon: "chart.bar.fill") {
+            LazyVGrid(columns: Array(repeating: GridItem(.flexible(), spacing: 10), count: 2), spacing: 10) {
+                HOFReportStatTile(title: "총 거리", value: viewModel.report.totalMileageText)
+                HOFReportStatTile(title: "러닝 횟수", value: viewModel.report.runCountText)
+                HOFReportStatTile(title: "함께한 시간", value: viewModel.report.totalDurationText)
+                HOFReportStatTile(title: "평균 거리", value: viewModel.report.averageDistanceText)
+                HOFReportStatTile(title: "평균 페이스", value: viewModel.report.averagePaceText)
+                HOFReportStatTile(title: "최장 러닝", value: viewModel.report.longestRunText)
+            }
+        }
+    }
+
+    private var memorableRunsSection: some View {
+        HOFReportSection(title: "대표 러닝", icon: "flag.checkered") {
+            VStack(spacing: 10) {
+                HOFDistanceRecordsBoard(
+                    records: viewModel.report.distanceRecords
+                )
+                
+                ForEach(viewModel.report.memorableRuns) { run in
+                    HOFMemorableRunRow(run: run)
+                }
+            }
+        }
+    }
+
+    private var mileageJourneySection: some View {
+        HOFReportSection(title: "마일리지 여정", icon: "point.topleft.down.curvedto.point.bottomright.up") {
+            VStack(alignment: .leading, spacing: 0) {
+                ForEach(viewModel.report.milestones) { milestone in
+                    HOFMileageMilestoneRow(milestone: milestone)
+                }
+            }
+        }
+    }
+
+    private var graduationMemoSection: some View {
+        HOFReportSection(title: "졸업 메모", icon: "square.and.pencil") {
+            VStack(alignment: .leading, spacing: 10) {
+                Text("이 신발과의 한 줄 메모")
+                    .font(.caption)
+                    .fontWeight(.black)
+                    .foregroundStyle(RunMileColor.primary)
+
+                Text(viewModel.report.graduationMemoTitle)
+                    .font(.title3)
+                    .fontWeight(.black)
+                    .foregroundStyle(RunMileColor.foreground)
+                    .fixedSize(horizontal: false, vertical: true)
+
+                Text("메모 편집 기능은 추후 연결 예정")
+                    .font(.caption)
+                    .fontWeight(.semibold)
+                    .foregroundStyle(RunMileColor.mutedForeground)
+            }
+            .padding(16)
+            .frame(maxWidth: .infinity, alignment: .leading)
+            .background(RunMileColor.card, in: RoundedRectangle(cornerRadius: RunMileRadius.card, style: .continuous))
+            .overlay {
+                RoundedRectangle(cornerRadius: RunMileRadius.card, style: .continuous)
+                    .stroke(RunMileColor.border, lineWidth: RunMileStroke.border)
+            }
+        }
+    }
+
+    private var shareCardSection: some View {
+        HOFReportSection(title: "공유 카드", icon: "square.and.arrow.up") {
+            VStack(spacing: 14) {
+                VStack(spacing: 8) {
+                    Text(viewModel.report.shareTitleText)
+                        .font(.title2)
+                        .fontWeight(.black)
+                        .foregroundStyle(RunMileColor.foreground)
+
+                    Text(viewModel.report.totalMileageText)
+                        .font(.system(size: 44, weight: .black))
+                        .foregroundStyle(RunMileColor.primary)
+
+                    Text(viewModel.report.shareCaptionText)
+                        .font(.caption)
+                        .fontWeight(.black)
+                        .foregroundStyle(RunMileColor.mutedForeground)
+                }
+                .padding(20)
+                .frame(maxWidth: .infinity)
+                .background(RunMileColor.muted, in: RoundedRectangle(cornerRadius: RunMileRadius.card, style: .continuous))
+                .overlay {
+                    RoundedRectangle(cornerRadius: RunMileRadius.card, style: .continuous)
+                        .stroke(RunMileColor.border, lineWidth: RunMileStroke.border)
+                }
+
+                ShareLink(item: viewModel.report.shareMessageText) {
+                    HStack {
+                        Image(systemName: "square.and.arrow.up")
+                        Text("공유 카드 만들기")
+                    }
+                    .runMileSecondaryButton()
+                }
+            }
+        }
+    }
+}
+
+
+#Preview("HOF Report") {
+    NavigationStack {
+        HOFReportView(
+            viewModel: PreviewDIContainer().makeHOFReportViewModel(
+                shoes: PreviewShoesMockData.hallOfFameShoes[0]
+            )
+        )
+    }
+}

--- a/Run Mile/Presentation/3.MyPage/3-1.HallOfFame/HOFReportViewModel.swift
+++ b/Run Mile/Presentation/3.MyPage/3-1.HallOfFame/HOFReportViewModel.swift
@@ -1,0 +1,393 @@
+//
+//  HOFReportViewModel.swift
+//  Run Mile
+//
+//  Created by Codex on 5/14/26.
+//
+
+import Foundation
+
+
+@Observable
+final class HOFReportViewModel {
+    private let shoes: Shoes
+    private let useCase: HOFUseCase
+    private var didLoadDistanceRecords = false
+    
+    let shoeImageData: Data
+    let shoeName: String
+    let shoeNickname: String
+    let goalMileageText: String
+    private(set) var report: HOFReportSummary
+    
+    init(shoes: Shoes, useCase: HOFUseCase) {
+        self.shoes = shoes
+        self.useCase = useCase
+        self.shoeImageData = shoes.image
+        self.shoeName = shoes.shoesName
+        self.shoeNickname = shoes.nickname
+        self.goalMileageText = "\(Int(shoes.goalMileage))km"
+        self.report = HOFReportSummary(shoes: shoes)
+    }
+    
+    /// 리포트 진입 시 세부 거리 샘플 기반 기록을 불러오고 앱 전체 PB 여부를 갱신합니다.
+    func onAppear() async {
+        guard await markDistanceRecordsLoadingIfNeeded() else { return }
+        
+        let shoeDistanceRecords = await useCase.fetchDistanceRecords(for: shoes.workouts)
+        await updateReport(
+            shoeDistanceRecords: shoeDistanceRecords,
+            appDistanceRecords: []
+        )
+        
+        do {
+            let allRunningWorkouts = try await useCase.fetchAllRunningWorkouts()
+            let appDistanceRecords = await useCase.fetchDistanceRecords(for: allRunningWorkouts)
+            await updateReport(
+                shoeDistanceRecords: shoeDistanceRecords,
+                appDistanceRecords: appDistanceRecords
+            )
+        } catch {
+            #if DEBUG
+            print("[HOFReport] app-wide PB comparison skipped: \(error.localizedDescription)")
+            #endif
+        }
+    }
+    
+    /// 거리 기록 로딩 중복 실행을 방지합니다.
+    @MainActor
+    private func markDistanceRecordsLoadingIfNeeded() -> Bool {
+        guard !didLoadDistanceRecords else { return false }
+        didLoadDistanceRecords = true
+        return true
+    }
+    
+    /// 신발 이미지를 자세히 볼 수 있는 이미지 상세 화면으로 이동합니다.
+    @MainActor
+    func imageTapped() {
+        let currentTab = NavigationCoordinator.shared.tabStatus
+        NavigationCoordinator.shared.push(.imageDetail(shoes.image), tab: currentTab)
+    }
+    
+    /// 거리별 최고 기록 계산 결과를 화면 표시 모델에 반영합니다.
+    @MainActor
+    private func updateReport(
+        shoeDistanceRecords: [WorkoutDistanceRecord],
+        appDistanceRecords: [WorkoutDistanceRecord]
+    ) {
+        let loadedReport = HOFReportSummary(
+            shoes: shoes,
+            shoeDistanceRecords: shoeDistanceRecords,
+            appDistanceRecords: appDistanceRecords,
+            didLoadDistanceRecords: true
+        )
+        
+        report = loadedReport
+    }
+}
+
+
+struct HOFReportSummary {
+    private let shoes: Shoes
+    private let workouts: [Workout]
+    private let bestShoeRecords: [WorkoutDistanceRecordTarget: WorkoutDistanceRecord]
+    private let bestAppRecords: [WorkoutDistanceRecordTarget: WorkoutDistanceRecord]
+    private let didLoadDistanceRecords: Bool
+    
+    init(
+        shoes: Shoes,
+        shoeDistanceRecords: [WorkoutDistanceRecord] = [],
+        appDistanceRecords: [WorkoutDistanceRecord] = [],
+        didLoadDistanceRecords: Bool = false
+    ) {
+        self.shoes = shoes
+        self.workouts = Self.uniqueWorkouts(shoes.workouts).sorted { $0.date < $1.date }
+        self.bestShoeRecords = Self.bestRecordsByTarget(shoeDistanceRecords)
+        self.bestAppRecords = Self.bestRecordsByTarget(appDistanceRecords)
+        self.didLoadDistanceRecords = didLoadDistanceRecords
+    }
+    
+    private var totalWorkoutDistance: Double {
+        workouts.reduce(0) { $0 + $1.distance }
+    }
+    
+    private var totalDuration: Double {
+        workouts.reduce(0) { $0 + $1.time }
+    }
+    
+    var totalMileageText: String {
+        String(format: "%.1fkm", shoes.totalMileage)
+    }
+    
+    var achievementRate: Int {
+        guard shoes.goalMileage > 0 else { return 0 }
+        return Int((shoes.totalMileage / shoes.goalMileage * 100).rounded())
+    }
+    
+    var activeDays: Int {
+        guard let first = workouts.first?.date, let last = workouts.last?.date else { return 1 }
+        let days = Calendar.current.dateComponents([.day], from: first, to: last).day ?? 0
+        return max(days + 1, 1)
+    }
+    
+    var dateRangeText: String {
+        guard let first = workouts.first?.date, let last = workouts.last?.date else { return "기록 준비 중" }
+        return "\(Self.dateFormatter.string(from: first)) - \(Self.dateFormatter.string(from: last))"
+    }
+    
+    var totalDurationText: String {
+        let hours = Int(totalDuration / 3600)
+        let minutes = Int(totalDuration.truncatingRemainder(dividingBy: 3600) / 60)
+        return hours > 0 ? "\(hours)시간 \(minutes)분" : "\(minutes)분"
+    }
+    
+    var runCountText: String {
+        "\(workouts.count)회"
+    }
+    
+    var averageDistanceText: String {
+        guard !workouts.isEmpty else { return "0.0km" }
+        return String(format: "%.1fkm", (totalWorkoutDistance / 1000) / Double(workouts.count))
+    }
+    
+    var averagePaceText: String {
+        guard totalWorkoutDistance > 0 else { return "--" }
+        return Self.paceText(secondsPerKilometer: totalDuration / (totalWorkoutDistance / 1000))
+    }
+    
+    var longestRunText: String {
+        guard let workout = workouts.max(by: { $0.distance < $1.distance }) else { return "--" }
+        return String(format: "%.1fkm", workout.distance / 1000)
+    }
+    
+    var aiSummaryText: String {
+        "\(shoes.nickname)은 총 \(workouts.count)번의 러닝과 함께한 신발이에요. 목표 마일리지의 \(achievementRate)%를 달성했고, 평균 \(averageDistanceText) 러닝에 꾸준히 사용된 패턴이 보입니다."
+    }
+    
+    var shareTitleText: String {
+        "\(shoes.nickname) 졸업"
+    }
+    
+    var shareCaptionText: String {
+        "\(workouts.count) Runs · Longest \(longestRunText)"
+    }
+    
+    var shareMessageText: String {
+        "\(shareTitleText)\n총 \(totalMileageText)를 함께 달렸어요.\n\(shareCaptionText)"
+    }
+    
+    var graduationMemoTitle: String {
+        "첫 장거리 훈련을 함께 버텨준 신발"
+    }
+    
+    var distanceRecords: [HOFDistanceRecord] {
+        WorkoutDistanceRecordTarget.allCases.map { makeDistanceRecord(for: $0) }
+    }
+    
+    var memorableRuns: [HOFMemorableRun] {
+        var runs: [HOFMemorableRun] = []
+        
+        if let first = workouts.first {
+            runs.append(makeRun(title: "첫 러닝", icon: "sparkles", workout: first, isPrimary: true))
+        }
+        
+        if let longest = workouts.max(by: { $0.distance < $1.distance }) {
+            runs.append(makeRun(title: "최장 러닝", icon: "arrow.up.forward", workout: longest, isPrimary: false))
+        }
+        
+        if let last = workouts.last {
+            runs.append(makeRun(title: "마지막 러닝", icon: "flag.checkered", workout: last, isPrimary: false))
+        }
+        
+        return Array(runs.prefix(4))
+    }
+    
+    var milestones: [HOFMileageMilestone] {
+        guard shoes.goalMileage > 0 else {
+            return [
+                HOFMileageMilestone(
+                    title: "졸업",
+                    dateText: workouts.last.map { Self.dateFormatter.string(from: $0.date) } ?? "날짜 준비 중",
+                    isGraduation: true
+                )
+            ]
+        }
+        
+        let baseMilestones = [100, 300, 500].filter {
+            Double($0) < shoes.goalMileage && Double($0) <= shoes.totalMileage
+        }
+        let goal = Int(shoes.goalMileage)
+        let values = baseMilestones + [goal]
+        
+        var result = values.map { value in
+            HOFMileageMilestone(
+                title: "\(value)km 달성",
+                dateText: estimatedDateText(for: Double(value)),
+                isGraduation: false
+            )
+        }
+        
+        result.append(
+            HOFMileageMilestone(
+                title: "졸업",
+                dateText: workouts.last.map { Self.dateFormatter.string(from: $0.date) } ?? "날짜 준비 중",
+                isGraduation: true
+            )
+        )
+        
+        return result
+    }
+    
+    private func makeRun(title: String, icon: String, workout: Workout, isPrimary: Bool) -> HOFMemorableRun {
+        HOFMemorableRun(
+            title: title,
+            icon: icon,
+            detail: "\(Self.dateFormatter.string(from: workout.date)) · \(String(format: "%.1fkm", workout.distance / 1000)) · \(workout.avgPace)",
+            isPrimary: isPrimary
+        )
+    }
+    
+    private func estimatedDateText(for mileage: Double) -> String {
+        guard !workouts.isEmpty else {
+            return "날짜 준비 중"
+        }
+        
+        if mileage <= shoes.currentMileage {
+            return "등록 이전 기록"
+        }
+        
+        var accumulatedMileage = shoes.currentMileage
+        for workout in workouts {
+            accumulatedMileage += workout.distance / 1000
+            if accumulatedMileage >= mileage {
+                return Self.dateFormatter.string(from: workout.date)
+            }
+        }
+        
+        return workouts.last.map { Self.dateFormatter.string(from: $0.date) } ?? "날짜 준비 중"
+    }
+    
+    /// UseCase가 계산한 세부 스플릿 기록을 HOF 카드 표시 모델로 변환합니다.
+    private func makeDistanceRecord(for target: WorkoutDistanceRecordTarget) -> HOFDistanceRecord {
+        guard didLoadDistanceRecords else {
+            return HOFDistanceRecord(
+                title: target.title,
+                timeText: "--",
+                detailText: "기록 불러오는 중",
+                workoutID: nil,
+                isPersonalBest: false,
+                isAvailable: false
+            )
+        }
+        
+        guard let shoeRecord = bestShoeRecords[target] else {
+            return HOFDistanceRecord(
+                title: target.title,
+                timeText: "--",
+                detailText: target.unavailableText,
+                workoutID: nil,
+                isPersonalBest: false,
+                isAvailable: false
+            )
+        }
+        
+        let appBestRecord = bestAppRecords[target]
+        let isPersonalBest = appBestRecord?.workoutID == shoeRecord.workoutID
+        let recordScopeText = isPersonalBest ? "PB" : "이 신발 최고"
+        let detailText = "\(Self.dateFormatter.string(from: shoeRecord.workoutDate)) · \(recordScopeText)"
+        
+        return HOFDistanceRecord(
+            title: target.title,
+            timeText: Self.recordDurationText(seconds: shoeRecord.duration),
+            detailText: detailText,
+            workoutID: shoeRecord.workoutID,
+            isPersonalBest: isPersonalBest,
+            isAvailable: true
+        )
+    }
+    
+    private static func paceText(secondsPerKilometer: Double) -> String {
+        guard secondsPerKilometer.isFinite else { return "--" }
+        let minutes = Int(secondsPerKilometer) / 60
+        let seconds = Int(secondsPerKilometer) % 60
+        return String(format: "%d'%02d\"", minutes, seconds)
+    }
+    
+    private static func recordDurationText(seconds: TimeInterval) -> String {
+        let totalSeconds = max(Int(seconds.rounded()), 0)
+        let hours = totalSeconds / 3600
+        let minutes = (totalSeconds % 3600) / 60
+        let seconds = totalSeconds % 60
+        
+        if hours > 0 {
+            return String(format: "%d:%02d:%02d", hours, minutes, seconds)
+        } else {
+            return String(format: "%02d:%02d", minutes, seconds)
+        }
+    }
+    
+    private static func uniqueWorkouts(_ workouts: [Workout]) -> [Workout] {
+        var seenIds: Set<UUID> = []
+        var result: [Workout] = []
+        
+        for workout in workouts where !seenIds.contains(workout.id) {
+            seenIds.insert(workout.id)
+            result.append(workout)
+        }
+        
+        return result
+    }
+    
+    /// 거리 타겟별 가장 빠른 기록을 미리 계산해 화면 갱신 시 반복 필터링을 줄입니다.
+    private static func bestRecordsByTarget(_ records: [WorkoutDistanceRecord]) -> [WorkoutDistanceRecordTarget: WorkoutDistanceRecord] {
+        var result: [WorkoutDistanceRecordTarget: WorkoutDistanceRecord] = [:]
+        
+        for record in records {
+            if let current = result[record.target] {
+                if record.duration < current.duration {
+                    result[record.target] = record
+                }
+            } else {
+                result[record.target] = record
+            }
+        }
+        
+        return result
+    }
+    
+    private static let dateFormatter: DateFormatter = {
+        let formatter = DateFormatter()
+        formatter.locale = Locale(identifier: "ko_KR")
+        formatter.dateFormat = "yyyy.MM.dd"
+        return formatter
+    }()
+}
+
+
+struct HOFDistanceRecord: Identifiable {
+    let title: String
+    let timeText: String
+    let detailText: String
+    let workoutID: UUID?
+    let isPersonalBest: Bool
+    let isAvailable: Bool
+    
+    var id: String { title }
+}
+
+
+struct HOFMemorableRun: Identifiable {
+    let id = UUID()
+    let title: String
+    let icon: String
+    let detail: String
+    let isPrimary: Bool
+}
+
+
+struct HOFMileageMilestone: Identifiable {
+    let id = UUID()
+    let title: String
+    let dateText: String
+    let isGraduation: Bool
+}

--- a/Run Mile/Presentation/3.MyPage/3-1.HallOfFame/HOFView.swift
+++ b/Run Mile/Presentation/3.MyPage/3-1.HallOfFame/HOFView.swift
@@ -9,38 +9,39 @@ import SwiftUI
 
 struct HOFView: View {
     @State private var viewModel: HOFViewModel
-    
+
     init(viewModel: HOFViewModel) {
         self.viewModel = viewModel
     }
-    
+
     var body: some View {
         ZStack(alignment: .top) {
             RunMileColor.background
                 .ignoresSafeArea()
-            
+
             RunMileColor.muted
                 .frame(height: 120)
                 .frame(maxHeight: .infinity, alignment: .top)
                 .ignoresSafeArea(edges: .top)
-            
+
             ScrollView {
                 VStack(spacing: 24) {
                     // MARK: - Header Section
                     headerView
                         .padding(.top, 10)
-                    
+
                     // MARK: - Shoes List
-                    if viewModel.shoes.isEmpty {
+                    if viewModel.shoeCards.isEmpty {
                         emptyStateView
                     } else {
                         LazyVStack(spacing: 16) {
-                            ForEach(viewModel.shoes) { shoes in
+                            ForEach(viewModel.shoeCards) { card in
                                 Button {
-                                    self.viewModel.shoesCellTapped(shoes: shoes)
+                                    self.viewModel.shoesCellTapped(card: card)
                                 } label: {
-                                    HOFShoesCard(shoes: shoes)
+                                    HOFShoesCard(card: card)
                                 }
+                                .buttonStyle(.plain)
                             }
                         }
                         .padding(.horizontal, 20)
@@ -60,7 +61,7 @@ struct HOFView: View {
             await viewModel.onAppear()
         }
     }
-    
+
     // MARK: - Subviews
     private var headerView: some View {
         VStack(spacing: 8) {
@@ -68,18 +69,18 @@ struct HOFView: View {
                 .font(.system(size: 60))
                 .foregroundStyle(RunMileColor.secondary)
                 .padding(.bottom, 8)
-            
+
             Text("LEGENDARY")
                 .font(.caption)
                 .fontWeight(.black)
                 .foregroundStyle(RunMileColor.primary)
                 .tracking(2)
-            
+
             Text("명예의 전당")
                 .font(.largeTitle)
                 .fontWeight(.heavy)
                 .foregroundStyle(RunMileColor.foreground)
-            
+
             Text("목표를 달성한 전설적인 신발들입니다.")
                 .font(.subheadline)
                 .foregroundStyle(RunMileColor.mutedForeground)
@@ -88,26 +89,26 @@ struct HOFView: View {
         .padding(.vertical, 30)
         .padding(.bottom, 10)
     }
-    
+
     private var emptyStateView: some View {
         VStack(spacing: 16) {
             Spacer()
                 .frame(height: 40)
-            
+
             Image(systemName: "trophy")
                 .font(.system(size: 80))
                 .foregroundStyle(RunMileColor.secondary)
-            
+
             Text("아직 전설이 된 신발이 없습니다.")
                 .font(.title3)
                 .fontWeight(.bold)
                 .foregroundStyle(RunMileColor.foreground)
-            
+
             Text("꾸준한 러닝으로 마일리지를 채워\n명예의 전당에 이름을 올려보세요!")
                 .font(.subheadline)
                 .foregroundStyle(RunMileColor.mutedForeground)
                 .multilineTextAlignment(.center)
-            
+
             Spacer()
         }
         .padding(40)
@@ -117,12 +118,11 @@ struct HOFView: View {
 // MARK: - Components
 
 struct HOFShoesCard: View {
-    let shoes: Shoes
-    
+    let card: HOFShoesCardInfo
+
     var body: some View {
         HStack(spacing: 16) {
-            // Shoe Image
-            if let uiImage = UIImage(data: shoes.image) {
+            if let uiImage = UIImage(data: card.imageData) {
                 Image(uiImage: uiImage)
                     .resizable()
                     .scaledToFit()
@@ -144,47 +144,57 @@ struct HOFShoesCard: View {
                     .overlay {
                         RoundedRectangle(cornerRadius: RunMileRadius.image, style: .continuous)
                             .strokeBorder(RunMileColor.border, lineWidth: RunMileStroke.border)
-                    }
-            }
-            
-            // Info
-            VStack(alignment: .leading, spacing: 6) {
-                HStack {
-                    Text(shoes.nickname)
-                        .font(.headline)
-                        .foregroundStyle(RunMileColor.foreground)
-                        .lineLimit(1)
-                    
-                    Spacer()
-                    
-                    Image(systemName: "laurel.leading")
-                        .foregroundStyle(RunMileColor.secondary)
                 }
-                
-                Text(shoes.shoesName)
+            }
+
+            VStack(alignment: .leading, spacing: 6) {
+                Text("졸업 리포트")
+                    .font(.caption2)
+                    .fontWeight(.black)
+                    .foregroundStyle(RunMileColor.primaryForeground)
+                    .padding(.horizontal, 8)
+                    .padding(.vertical, 4)
+                    .background(RunMileColor.primary, in: RoundedRectangle(cornerRadius: RunMileRadius.progress, style: .continuous))
+                    .overlay {
+                        RoundedRectangle(cornerRadius: RunMileRadius.progress, style: .continuous)
+                            .stroke(RunMileColor.border, lineWidth: RunMileStroke.hairline)
+                    }
+
+                Text(card.nickname)
+                    .font(.headline)
+                    .foregroundStyle(RunMileColor.foreground)
+                    .lineLimit(1)
+
+                Text(card.shoesName)
                     .font(.caption)
                     .foregroundStyle(RunMileColor.mutedForeground)
                     .lineLimit(1)
-                
+
                 Spacer()
-                
+
                 HStack(alignment: .bottom, spacing: 4) {
-                    Text("\(Int(shoes.totalMileage))")
+                    Text(card.totalMileageText)
                         .font(.title3)
                         .fontWeight(.bold)
                         .foregroundStyle(RunMileColor.foreground)
-                    
+
                     Text("km 달성")
                         .font(.caption)
                         .fontWeight(.semibold)
                         .foregroundStyle(RunMileColor.mutedForeground)
                         .padding(.bottom, 2)
+
+                    Text("· \(card.achievementRateText)")
+                        .font(.caption)
+                        .fontWeight(.bold)
+                        .foregroundStyle(RunMileColor.primary)
+                        .padding(.bottom, 2)
                 }
             }
             .padding(.vertical, 8)
-            
+
             Spacer()
-            
+
             Image(systemName: "chevron.right")
                 .font(.subheadline)
                 .foregroundStyle(RunMileColor.mutedForeground)

--- a/Run Mile/Presentation/3.MyPage/3-1.HallOfFame/HOFViewModel.swift
+++ b/Run Mile/Presentation/3.MyPage/3-1.HallOfFame/HOFViewModel.swift
@@ -10,7 +10,12 @@ import Foundation
 
 @Observable
 final class HOFViewModel {
-    public var shoes: [Shoes] = []
+    public var shoes: [Shoes] = [] {
+        didSet {
+            shoeCards = shoes.map(HOFShoesCardInfo.init)
+        }
+    }
+    public private(set) var shoeCards: [HOFShoesCardInfo] = []
     
     
     private let useCase: HOFUseCase
@@ -22,6 +27,7 @@ final class HOFViewModel {
 
 
 extension HOFViewModel {
+    /// 명예의 전당에 진입할 때 졸업 신발 목록을 불러와 카드 표시 모델로 변환합니다.
     @MainActor
     public func onAppear() async {
         do {
@@ -36,8 +42,37 @@ extension HOFViewModel {
         }
     }
     
+    /// 선택한 졸업 신발의 리포트 화면으로 이동합니다.
     @MainActor
-    public func shoesCellTapped(shoes: Shoes) {
-        NavigationCoordinator.shared.push(.shoesDetail(shoes), tab: .myPage)
+    public func shoesCellTapped(card: HOFShoesCardInfo) {
+        NavigationCoordinator.shared.push(.hofReport(card.shoes), tab: .myPage)
+    }
+}
+
+
+struct HOFShoesCardInfo: Identifiable {
+    let id: UUID
+    let shoes: Shoes
+    let imageData: Data
+    let nickname: String
+    let shoesName: String
+    let totalMileageText: String
+    let achievementRateText: String
+    
+    init(shoes: Shoes) {
+        self.id = shoes.id
+        self.shoes = shoes
+        self.imageData = shoes.image
+        self.nickname = shoes.nickname
+        self.shoesName = shoes.shoesName
+        self.totalMileageText = "\(Int(shoes.totalMileage))"
+        
+        let achievementRate: Int
+        if shoes.goalMileage > 0 {
+            achievementRate = Int((shoes.totalMileage / shoes.goalMileage * 100).rounded())
+        } else {
+            achievementRate = 0
+        }
+        self.achievementRateText = "목표 \(achievementRate)%"
     }
 }

--- a/Run Mile/Presentation/3.MyPage/3-1.HallOfFame/Preview/HOFReportDataPreviewView.swift
+++ b/Run Mile/Presentation/3.MyPage/3-1.HallOfFame/Preview/HOFReportDataPreviewView.swift
@@ -1,0 +1,714 @@
+//
+//  HOFReportDataPreviewView.swift
+//  Run Mile
+//
+//  Created by Codex on 5/13/26.
+//
+
+import SwiftUI
+
+
+struct HOFReportDataPreviewView: View {
+    private let report = HOFDataPreviewReport.sample
+
+    var body: some View {
+        ScrollView {
+            VStack(spacing: 18) {
+                compactHero
+                summaryBar
+                careerReport
+                memorableRuns
+                mileageJourney
+                usagePattern
+                latePhaseChange
+                previewActions
+            }
+            .padding(.vertical, 18)
+        }
+        .background(RunMileColor.background)
+        .navigationTitle("졸업 데이터 리포트")
+        .navigationBarTitleDisplayMode(.inline)
+        .toolbarBackground(.hidden, for: .navigationBar)
+    }
+
+    private var compactHero: some View {
+        HStack(alignment: .center, spacing: 16) {
+            shoeSymbol
+
+            VStack(alignment: .leading, spacing: 8) {
+                Text("LEGENDARY REPORT")
+                    .font(.caption2)
+                    .fontWeight(.black)
+                    .foregroundStyle(RunMileColor.primary)
+                    .tracking(1.4)
+
+                Text(report.nickname)
+                    .font(.title2)
+                    .fontWeight(.black)
+                    .foregroundStyle(RunMileColor.foreground)
+                    .lineLimit(1)
+                    .minimumScaleFactor(0.72)
+
+                Text(report.model)
+                    .font(.caption)
+                    .fontWeight(.semibold)
+                    .foregroundStyle(RunMileColor.mutedForeground)
+                    .lineLimit(2)
+
+                HStack(alignment: .firstTextBaseline, spacing: 6) {
+                    Text(report.totalDistance)
+                        .font(.system(size: 34, weight: .black))
+                        .foregroundStyle(RunMileColor.foreground)
+                        .lineLimit(1)
+                        .minimumScaleFactor(0.72)
+
+                    Text("목표 \(report.goalRate)")
+                        .font(.caption)
+                        .fontWeight(.black)
+                        .foregroundStyle(RunMileColor.primary)
+                }
+
+                Text(report.activePeriod)
+                    .font(.caption)
+                    .fontWeight(.bold)
+                    .foregroundStyle(RunMileColor.mutedForeground)
+            }
+
+            Spacer(minLength: 0)
+        }
+        .padding(18)
+        .runMileBrutalCard()
+        .padding(.horizontal)
+    }
+
+    private var shoeSymbol: some View {
+        ZStack {
+            RunMileColor.secondary
+
+            Image(systemName: "shoe.fill")
+                .font(.system(size: 54, weight: .black))
+                .foregroundStyle(RunMileColor.foreground)
+                .rotationEffect(.degrees(-8))
+        }
+        .frame(width: 108, height: 108)
+        .overlay {
+            RoundedRectangle(cornerRadius: RunMileRadius.image, style: .continuous)
+                .stroke(RunMileColor.border, lineWidth: RunMileStroke.border)
+        }
+        .shadow(color: RunMileColor.border, radius: 0, x: 4, y: 4)
+    }
+
+    private var summaryBar: some View {
+        HStack(spacing: 8) {
+            HOFDataPreviewSummaryMetric(title: "거리", value: report.totalDistance)
+            HOFDataPreviewSummaryMetric(title: "러닝", value: report.runCount)
+            HOFDataPreviewSummaryMetric(title: "시간", value: report.totalTime)
+        }
+        .padding(.horizontal)
+    }
+
+    private var careerReport: some View {
+        HOFDataPreviewSection(title: "커리어 리포트", icon: "chart.bar.fill") {
+            LazyVGrid(columns: gridColumns, spacing: 10) {
+                ForEach(report.careerMetrics) { metric in
+                    HOFDataPreviewMetricCard(metric: metric)
+                }
+            }
+        }
+    }
+
+    private var memorableRuns: some View {
+        HOFDataPreviewSection(title: "대표 러닝", icon: "flag.checkered") {
+            VStack(spacing: 10) {
+                HOFDataPreviewRecordBoard(records: report.distanceRecords)
+                
+                ForEach(report.memorableRuns) { run in
+                    HOFDataPreviewRunRow(run: run)
+                }
+            }
+        }
+    }
+
+    private var mileageJourney: some View {
+        HOFDataPreviewSection(title: "마일리지 여정", icon: "trophy.fill") {
+            VStack(alignment: .leading, spacing: 0) {
+                ForEach(Array(report.milestones.enumerated()), id: \.element.id) { index, milestone in
+                    HOFDataPreviewMilestoneRow(
+                        milestone: milestone,
+                        isLast: index == report.milestones.count - 1
+                    )
+                }
+            }
+        }
+    }
+
+    private var usagePattern: some View {
+        HOFDataPreviewSection(title: "사용 패턴", icon: "scope") {
+            VStack(spacing: 12) {
+                HOFDataPreviewDistributionBar(items: report.distanceMix)
+
+                VStack(alignment: .leading, spacing: 8) {
+                    HOFDataPreviewInsightRow(icon: "moon.fill", text: "평일 저녁 러닝 비중이 가장 높았습니다.")
+                    HOFDataPreviewInsightRow(icon: "figure.run", text: "5~8km 데일리 러닝에 가장 자주 사용됐습니다.")
+                    HOFDataPreviewInsightRow(icon: "sparkles", text: "꾸준한 훈련용 신발로 사용된 패턴이 보입니다.")
+                }
+            }
+        }
+    }
+
+    private var latePhaseChange: some View {
+        HOFDataPreviewSection(title: "후반부 변화", icon: "arrow.triangle.2.circlepath") {
+            VStack(spacing: 12) {
+                HStack(spacing: 10) {
+                    HOFDataPreviewCompareCard(title: "첫 100km", value: "5'36\"", caption: "평균 페이스")
+                    HOFDataPreviewCompareCard(title: "마지막 100km", value: "5'51\"", caption: "평균 페이스")
+                }
+
+                Text("후반부에는 장거리보다 짧은 러닝 비중이 늘었습니다. 신발 상태, 코스, 컨디션이 함께 영향을 줬을 가능성이 있어요.")
+                    .font(.subheadline)
+                    .fontWeight(.semibold)
+                    .foregroundStyle(RunMileColor.mutedForeground)
+                    .fixedSize(horizontal: false, vertical: true)
+                    .padding(14)
+                    .frame(maxWidth: .infinity, alignment: .leading)
+                    .background(RunMileColor.muted, in: RoundedRectangle(cornerRadius: RunMileRadius.card, style: .continuous))
+                    .overlay {
+                        RoundedRectangle(cornerRadius: RunMileRadius.card, style: .continuous)
+                            .stroke(RunMileColor.border, lineWidth: RunMileStroke.hairline)
+                    }
+            }
+        }
+    }
+
+    private var previewActions: some View {
+        HOFDataPreviewSection(title: "다음 액션", icon: "square.and.arrow.up") {
+            HStack(spacing: 10) {
+                HOFDataPreviewActionButton(icon: "square.and.pencil", title: "메모")
+                HOFDataPreviewActionButton(icon: "square.and.arrow.up", title: "공유 카드")
+            }
+        }
+        .padding(.bottom, 20)
+    }
+
+    private var gridColumns: [GridItem] {
+        [
+            GridItem(.flexible(), spacing: 10),
+            GridItem(.flexible(), spacing: 10)
+        ]
+    }
+}
+
+
+private struct HOFDataPreviewSection<Content: View>: View {
+    let title: String
+    let icon: String
+    @ViewBuilder let content: Content
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 14) {
+            Label(title, systemImage: icon)
+                .font(.title3)
+                .fontWeight(.black)
+                .foregroundStyle(RunMileColor.foreground)
+
+            content
+        }
+        .padding(18)
+        .runMileBrutalCard()
+        .padding(.horizontal)
+    }
+}
+
+
+private struct HOFDataPreviewSummaryMetric: View {
+    let title: String
+    let value: String
+
+    var body: some View {
+        VStack(spacing: 5) {
+            Text(title)
+                .font(.caption2)
+                .fontWeight(.black)
+                .foregroundStyle(RunMileColor.mutedForeground)
+
+            Text(value)
+                .font(.headline)
+                .fontWeight(.black)
+                .foregroundStyle(RunMileColor.foreground)
+                .lineLimit(1)
+                .minimumScaleFactor(0.68)
+        }
+        .frame(maxWidth: .infinity)
+        .padding(.vertical, 12)
+        .background(RunMileColor.card, in: RoundedRectangle(cornerRadius: RunMileRadius.card, style: .continuous))
+        .overlay {
+            RoundedRectangle(cornerRadius: RunMileRadius.card, style: .continuous)
+                .stroke(RunMileColor.border, lineWidth: RunMileStroke.border)
+        }
+        .shadow(color: RunMileColor.border, radius: 0, x: 3, y: 3)
+    }
+}
+
+
+private struct HOFDataPreviewMetricCard: View {
+    let metric: HOFDataPreviewMetric
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 8) {
+            Image(systemName: metric.icon)
+                .font(.caption)
+                .fontWeight(.black)
+                .foregroundStyle(metric.isHighlighted ? RunMileColor.secondaryForeground : RunMileColor.primaryForeground)
+                .frame(width: 28, height: 28)
+                .background(metric.isHighlighted ? RunMileColor.secondary : RunMileColor.primary, in: RoundedRectangle(cornerRadius: RunMileRadius.small, style: .continuous))
+                .overlay {
+                    RoundedRectangle(cornerRadius: RunMileRadius.small, style: .continuous)
+                        .stroke(RunMileColor.border, lineWidth: RunMileStroke.hairline)
+                }
+
+            Text(metric.title)
+                .font(.caption)
+                .fontWeight(.black)
+                .foregroundStyle(RunMileColor.mutedForeground)
+
+            Text(metric.value)
+                .font(.headline)
+                .fontWeight(.black)
+                .foregroundStyle(RunMileColor.foreground)
+                .lineLimit(1)
+                .minimumScaleFactor(0.72)
+        }
+        .padding(12)
+        .frame(maxWidth: .infinity, alignment: .leading)
+        .background(RunMileColor.muted, in: RoundedRectangle(cornerRadius: RunMileRadius.card, style: .continuous))
+        .overlay {
+            RoundedRectangle(cornerRadius: RunMileRadius.card, style: .continuous)
+                .stroke(RunMileColor.border, lineWidth: RunMileStroke.hairline)
+        }
+    }
+}
+
+
+private struct HOFDataPreviewRecordBoard: View {
+    let records: [HOFDataPreviewRecord]
+    
+    private var columns: [GridItem] {
+        [
+            GridItem(.flexible(), spacing: 10),
+            GridItem(.flexible(), spacing: 10)
+        ]
+    }
+    
+    var body: some View {
+        VStack(alignment: .leading, spacing: 12) {
+            HStack(spacing: 8) {
+                Image(systemName: "rosette")
+                    .font(.headline.weight(.black))
+                
+                Text("거리별 최고 기록")
+                    .font(.headline)
+                    .fontWeight(.black)
+                    .foregroundStyle(RunMileColor.foreground)
+                
+                Spacer()
+            }
+            
+            LazyVGrid(columns: columns, spacing: 10) {
+                ForEach(records) { record in
+                    HOFDataPreviewRecordTile(record: record)
+                }
+            }
+            
+            Text("해당 신발 최고 기록을 먼저 보여주고, 앱 전체 최고 기록이면 PB 배지를 붙입니다.")
+                .font(.caption2)
+                .fontWeight(.semibold)
+                .foregroundStyle(RunMileColor.mutedForeground)
+                .fixedSize(horizontal: false, vertical: true)
+        }
+        .padding(14)
+        .frame(maxWidth: .infinity, alignment: .leading)
+        .background(RunMileColor.muted, in: RoundedRectangle(cornerRadius: RunMileRadius.card, style: .continuous))
+        .overlay {
+            RoundedRectangle(cornerRadius: RunMileRadius.card, style: .continuous)
+                .stroke(RunMileColor.border, lineWidth: RunMileStroke.border)
+        }
+    }
+}
+
+
+private struct HOFDataPreviewRecordTile: View {
+    let record: HOFDataPreviewRecord
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 9) {
+            HStack(spacing: 6) {
+                Text(record.title)
+                    .font(.caption)
+                    .fontWeight(.black)
+                    .foregroundStyle(record.isAvailable ? RunMileColor.primary : RunMileColor.mutedForeground)
+
+                Spacer(minLength: 4)
+
+                if record.isPersonalBest {
+                    Text("PB")
+                        .font(.caption2)
+                        .fontWeight(.black)
+                        .foregroundStyle(RunMileColor.secondaryForeground)
+                        .padding(.horizontal, 7)
+                        .padding(.vertical, 4)
+                        .background(RunMileColor.secondary, in: RoundedRectangle(cornerRadius: RunMileRadius.progress, style: .continuous))
+                        .overlay {
+                            RoundedRectangle(cornerRadius: RunMileRadius.progress, style: .continuous)
+                                .stroke(RunMileColor.border, lineWidth: RunMileStroke.hairline)
+                        }
+                }
+            }
+
+            Text(record.time)
+                .font(.title3)
+                .fontWeight(.black)
+                .foregroundStyle(record.isAvailable ? RunMileColor.foreground : RunMileColor.mutedForeground)
+                .lineLimit(1)
+                .minimumScaleFactor(0.78)
+
+            Text(record.detail)
+                .font(.caption2)
+                .fontWeight(.semibold)
+                .foregroundStyle(RunMileColor.mutedForeground)
+                .lineLimit(2)
+                .minimumScaleFactor(0.82)
+        }
+        .padding(12)
+        .frame(minHeight: 106, alignment: .topLeading)
+        .frame(maxWidth: .infinity, alignment: .leading)
+        .background(record.isPersonalBest ? RunMileColor.secondary.opacity(0.22) : RunMileColor.card, in: RoundedRectangle(cornerRadius: RunMileRadius.card, style: .continuous))
+        .overlay {
+            RoundedRectangle(cornerRadius: RunMileRadius.card, style: .continuous)
+                .stroke(record.isPersonalBest ? RunMileColor.primary : RunMileColor.border, lineWidth: RunMileStroke.border)
+        }
+    }
+}
+
+
+private struct HOFDataPreviewRunRow: View {
+    let run: HOFDataPreviewRun
+
+    var body: some View {
+        HStack(spacing: 12) {
+            Text(run.badge)
+                .font(.caption)
+                .fontWeight(.black)
+                .foregroundStyle(run.isKey ? RunMileColor.secondaryForeground : RunMileColor.primaryForeground)
+                .frame(width: 44, height: 44)
+                .background(run.isKey ? RunMileColor.secondary : RunMileColor.primary, in: RoundedRectangle(cornerRadius: RunMileRadius.small, style: .continuous))
+                .overlay {
+                    RoundedRectangle(cornerRadius: RunMileRadius.small, style: .continuous)
+                        .stroke(RunMileColor.border, lineWidth: RunMileStroke.border)
+                }
+
+            VStack(alignment: .leading, spacing: 4) {
+                Text(run.title)
+                    .font(.subheadline)
+                    .fontWeight(.black)
+                    .foregroundStyle(RunMileColor.foreground)
+
+                Text(run.detail)
+                    .font(.caption)
+                    .fontWeight(.semibold)
+                    .foregroundStyle(RunMileColor.mutedForeground)
+                    .lineLimit(1)
+                    .minimumScaleFactor(0.78)
+            }
+
+            Spacer()
+
+            Image(systemName: "chevron.right")
+                .font(.caption)
+                .fontWeight(.black)
+                .foregroundStyle(RunMileColor.mutedForeground)
+        }
+        .padding(12)
+        .background(RunMileColor.card, in: RoundedRectangle(cornerRadius: RunMileRadius.card, style: .continuous))
+        .overlay {
+            RoundedRectangle(cornerRadius: RunMileRadius.card, style: .continuous)
+                .stroke(RunMileColor.border, lineWidth: RunMileStroke.border)
+        }
+    }
+}
+
+
+private struct HOFDataPreviewMilestoneRow: View {
+    let milestone: HOFDataPreviewMilestone
+    let isLast: Bool
+
+    var body: some View {
+        HStack(alignment: .top, spacing: 12) {
+            VStack(spacing: 0) {
+                Circle()
+                    .fill(milestone.isGraduation ? RunMileColor.primary : RunMileColor.secondary)
+                    .frame(width: 20, height: 20)
+                    .overlay {
+                        Circle()
+                            .stroke(RunMileColor.border, lineWidth: RunMileStroke.border)
+                    }
+
+                if !isLast {
+                    Rectangle()
+                        .fill(RunMileColor.border)
+                        .frame(width: 3, height: 34)
+                }
+            }
+
+            VStack(alignment: .leading, spacing: 4) {
+                Text(milestone.title)
+                    .font(.subheadline)
+                    .fontWeight(.black)
+                    .foregroundStyle(RunMileColor.foreground)
+
+                Text(milestone.date)
+                    .font(.caption)
+                    .fontWeight(.semibold)
+                    .foregroundStyle(RunMileColor.mutedForeground)
+            }
+            .padding(.bottom, isLast ? 0 : 16)
+
+            Spacer()
+        }
+    }
+}
+
+
+private struct HOFDataPreviewDistributionBar: View {
+    let items: [HOFDataPreviewDistribution]
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 10) {
+            HStack(spacing: 4) {
+                ForEach(items) { item in
+                    Rectangle()
+                        .fill(item.color)
+                        .frame(maxWidth: .infinity)
+                        .frame(height: 20)
+                        .layoutPriority(item.ratio)
+                        .overlay {
+                            Rectangle()
+                                .stroke(RunMileColor.border, lineWidth: RunMileStroke.hairline)
+                        }
+                }
+            }
+
+            ForEach(items) { item in
+                HStack(spacing: 8) {
+                    Rectangle()
+                        .fill(item.color)
+                        .frame(width: 14, height: 14)
+                        .overlay {
+                            Rectangle()
+                                .stroke(RunMileColor.border, lineWidth: RunMileStroke.hairline)
+                        }
+
+                    Text(item.title)
+                        .font(.caption)
+                        .fontWeight(.bold)
+                        .foregroundStyle(RunMileColor.foreground)
+
+                    Spacer()
+
+                    Text(item.percent)
+                        .font(.caption)
+                        .fontWeight(.black)
+                        .foregroundStyle(RunMileColor.mutedForeground)
+                }
+            }
+        }
+    }
+}
+
+
+private struct HOFDataPreviewInsightRow: View {
+    let icon: String
+    let text: String
+
+    var body: some View {
+        HStack(alignment: .top, spacing: 10) {
+            Image(systemName: icon)
+                .font(.caption)
+                .fontWeight(.black)
+                .foregroundStyle(RunMileColor.primary)
+                .frame(width: 22)
+
+            Text(text)
+                .font(.subheadline)
+                .fontWeight(.semibold)
+                .foregroundStyle(RunMileColor.mutedForeground)
+                .fixedSize(horizontal: false, vertical: true)
+        }
+    }
+}
+
+
+private struct HOFDataPreviewCompareCard: View {
+    let title: String
+    let value: String
+    let caption: String
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 6) {
+            Text(title)
+                .font(.caption)
+                .fontWeight(.black)
+                .foregroundStyle(RunMileColor.mutedForeground)
+
+            Text(value)
+                .font(.title2)
+                .fontWeight(.black)
+                .foregroundStyle(RunMileColor.foreground)
+
+            Text(caption)
+                .font(.caption2)
+                .fontWeight(.semibold)
+                .foregroundStyle(RunMileColor.mutedForeground)
+        }
+        .padding(12)
+        .frame(maxWidth: .infinity, alignment: .leading)
+        .background(RunMileColor.card, in: RoundedRectangle(cornerRadius: RunMileRadius.card, style: .continuous))
+        .overlay {
+            RoundedRectangle(cornerRadius: RunMileRadius.card, style: .continuous)
+                .stroke(RunMileColor.border, lineWidth: RunMileStroke.border)
+        }
+    }
+}
+
+
+private struct HOFDataPreviewActionButton: View {
+    let icon: String
+    let title: String
+
+    var body: some View {
+        HStack {
+            Image(systemName: icon)
+            Text(title)
+        }
+        .font(.headline)
+        .fontWeight(.black)
+        .foregroundStyle(RunMileColor.foreground)
+        .frame(maxWidth: .infinity)
+        .frame(height: 52)
+        .background(RunMileColor.card, in: RoundedRectangle(cornerRadius: RunMileRadius.button, style: .continuous))
+        .overlay {
+            RoundedRectangle(cornerRadius: RunMileRadius.button, style: .continuous)
+                .stroke(RunMileColor.border, lineWidth: RunMileStroke.border)
+        }
+        .shadow(color: RunMileColor.border, radius: 0, x: 4, y: 4)
+    }
+}
+
+
+private struct HOFDataPreviewReport {
+    let nickname: String
+    let model: String
+    let totalDistance: String
+    let goalRate: String
+    let activePeriod: String
+    let runCount: String
+    let totalTime: String
+    let careerMetrics: [HOFDataPreviewMetric]
+    let distanceRecords: [HOFDataPreviewRecord]
+    let memorableRuns: [HOFDataPreviewRun]
+    let milestones: [HOFDataPreviewMilestone]
+    let distanceMix: [HOFDataPreviewDistribution]
+
+    static let sample = HOFDataPreviewReport(
+        nickname: "첫 풀코스",
+        model: "Adidas Adizero Adios Pro 3",
+        totalDistance: "642.8km",
+        goalRate: "107%",
+        activePeriod: "2025.08.12 - 2026.02.03 · 176일",
+        runCount: "83회",
+        totalTime: "61h 24m",
+        careerMetrics: [
+            .init(title: "평균 거리", value: "7.7km", icon: "ruler", isHighlighted: true),
+            .init(title: "평균 페이스", value: "5'42\"", icon: "stopwatch.fill", isHighlighted: false),
+            .init(title: "최장 러닝", value: "21.1km", icon: "arrow.up.forward", isHighlighted: false),
+            .init(title: "최고 페이스", value: "4'52\"", icon: "bolt.fill", isHighlighted: true),
+            .init(title: "총 칼로리", value: "42,180kcal", icon: "flame.fill", isHighlighted: false),
+            .init(title: "최다 사용 월", value: "2025.11", icon: "calendar", isHighlighted: false)
+        ],
+        distanceRecords: [
+            .init(title: "5K", time: "24:18", detail: "2026.01.14 · 앱 전체 PB", isPersonalBest: true, isAvailable: true),
+            .init(title: "10K", time: "52:04", detail: "2025.11.03 · 이 신발 최고", isPersonalBest: false, isAvailable: true),
+            .init(title: "Half", time: "1:58:31", detail: "2025.12.21 · 앱 전체 PB", isPersonalBest: true, isAvailable: true),
+            .init(title: "Full", time: "--", detail: "해당 거리 이상 기록 없음", isPersonalBest: false, isAvailable: false)
+        ],
+        memorableRuns: [
+            .init(title: "첫 러닝", detail: "2025.08.12 · 5.2km · 5'58\"", badge: "1st", isKey: true),
+            .init(title: "최장 러닝", detail: "2025.11.03 · 21.1km · 6'04\"", badge: "L", isKey: false),
+            .init(title: "마지막 러닝", detail: "2026.02.03 · 7.4km · 5'47\"", badge: "END", isKey: false)
+        ],
+        milestones: [
+            .init(title: "100km 달성", date: "2025.09.01", isGraduation: false),
+            .init(title: "300km 달성", date: "2025.10.18", isGraduation: false),
+            .init(title: "500km 달성", date: "2025.12.09", isGraduation: false),
+            .init(title: "600km 목표 달성", date: "2026.01.22", isGraduation: false),
+            .init(title: "졸업", date: "2026.02.03", isGraduation: true)
+        ],
+        distanceMix: [
+            .init(title: "짧은 러닝 0-5km", percent: "18%", ratio: 0.18, color: RunMileColor.primary),
+            .init(title: "데일리 러닝 5-8km", percent: "62%", ratio: 0.62, color: RunMileColor.secondary),
+            .init(title: "장거리 10km+", percent: "20%", ratio: 0.20, color: RunMileColor.accent)
+        ]
+    )
+}
+
+
+private struct HOFDataPreviewMetric: Identifiable {
+    let id = UUID()
+    let title: String
+    let value: String
+    let icon: String
+    let isHighlighted: Bool
+}
+
+
+private struct HOFDataPreviewRecord: Identifiable {
+    let title: String
+    let time: String
+    let detail: String
+    let isPersonalBest: Bool
+    let isAvailable: Bool
+    
+    var id: String { title }
+}
+
+
+private struct HOFDataPreviewRun: Identifiable {
+    let id = UUID()
+    let title: String
+    let detail: String
+    let badge: String
+    let isKey: Bool
+}
+
+
+private struct HOFDataPreviewMilestone: Identifiable {
+    let id = UUID()
+    let title: String
+    let date: String
+    let isGraduation: Bool
+}
+
+
+private struct HOFDataPreviewDistribution: Identifiable {
+    let id = UUID()
+    let title: String
+    let percent: String
+    let ratio: Double
+    let color: Color
+}
+
+
+#Preview("HOF Data Report Preview") {
+    NavigationStack {
+        HOFReportDataPreviewView()
+    }
+}

--- a/Run Mile/Presentation/3.MyPage/3-1.HallOfFame/Preview/HOFShareCardVariantsPreviewView.swift
+++ b/Run Mile/Presentation/3.MyPage/3-1.HallOfFame/Preview/HOFShareCardVariantsPreviewView.swift
@@ -1,0 +1,566 @@
+//
+//  HOFShareCardVariantsPreviewView.swift
+//  Run Mile
+//
+//  Created by Codex on 5/15/26.
+//
+
+import SwiftUI
+
+
+struct HOFShareCardVariantsPreviewView: View {
+    private let sample = HOFShareCardSample.sample
+
+    var body: some View {
+        ScrollView {
+            VStack(alignment: .leading, spacing: 24) {
+                header
+
+                ScrollView(.horizontal, showsIndicators: false) {
+                    HStack(alignment: .top, spacing: 18) {
+                        HOFShareCardFrame(title: "A. Poster") {
+                            HOFPosterShareCard(sample: sample)
+                        }
+
+                        HOFShareCardFrame(title: "B. Split") {
+                            HOFSplitShareCard(sample: sample)
+                        }
+
+                        HOFShareCardFrame(title: "C. Overlay") {
+                            HOFOverlayShareCard(sample: sample)
+                        }
+
+                        HOFShareCardFrame(title: "D. Receipt") {
+                            HOFReceiptShareCard(sample: sample)
+                        }
+
+                        HOFShareCardFrame(title: "E. Trophy") {
+                            HOFTrophyShareCard(sample: sample)
+                        }
+                    }
+                    .padding(.horizontal, RunMileSpacing.screenHorizontal)
+                    .padding(.bottom, 8)
+                }
+
+                variantNotes
+            }
+            .padding(.vertical, 20)
+        }
+        .background(RunMileColor.background)
+        .navigationTitle("HOF 공유 카드 시안")
+        .navigationBarTitleDisplayMode(.inline)
+        .toolbarBackground(.hidden, for: .navigationBar)
+    }
+
+    private var header: some View {
+        VStack(alignment: .leading, spacing: 8) {
+            Text("INSTAGRAM STORY")
+                .font(.caption)
+                .fontWeight(.black)
+                .foregroundStyle(RunMileColor.primary)
+                .tracking(1.8)
+
+            Text("졸업 신발 공유 카드")
+                .font(.largeTitle)
+                .fontWeight(.black)
+                .foregroundStyle(RunMileColor.foreground)
+
+            Text("9:16 스토리 비율로 저장하거나 공유하기 좋은 방향의 시안입니다.")
+                .font(.subheadline)
+                .fontWeight(.semibold)
+                .foregroundStyle(RunMileColor.mutedForeground)
+        }
+        .padding(.horizontal, RunMileSpacing.screenHorizontal)
+    }
+
+    private var variantNotes: some View {
+        VStack(alignment: .leading, spacing: 10) {
+            HOFShareNote(title: "A Poster", description: "가장 대중적인 운동 앱 공유 카드 느낌. 큰 거리 수치와 신발 실루엣이 바로 보입니다.")
+            HOFShareNote(title: "B Split", description: "블랙 기반이라 스토리 피드에서 강하게 튑니다. 성취감과 브랜드감이 가장 강한 안입니다.")
+            HOFShareNote(title: "C Overlay", description: "사진/영상 위에 통계를 얹는 최신 공유 트렌드에 맞춘 안입니다. 나중에 사용자 사진과 결합하기 좋습니다.")
+            HOFShareNote(title: "D Receipt", description: "기록 영수증처럼 데이터가 촘촘하게 보이는 안입니다. 재미는 있지만 감정성은 조금 낮습니다.")
+            HOFShareNote(title: "E Trophy", description: "명예의 전당 콘셉트가 가장 직접적입니다. 졸업/달성의 기념비 느낌이 강합니다.")
+        }
+        .padding(18)
+        .runMileBrutalCard()
+        .padding(.horizontal)
+    }
+}
+
+
+private struct HOFShareCardFrame<Content: View>: View {
+    let title: String
+    @ViewBuilder let content: Content
+
+    var body: some View {
+        VStack(spacing: 10) {
+            content
+                .frame(width: 246)
+                .aspectRatio(9.0 / 16.0, contentMode: .fit)
+                .clipShape(Rectangle())
+                .overlay {
+                    Rectangle()
+                        .stroke(RunMileColor.border, lineWidth: RunMileStroke.border)
+                }
+                .shadow(color: RunMileColor.border, radius: 0, x: 5, y: 5)
+
+            Text(title)
+                .font(.caption)
+                .fontWeight(.black)
+                .foregroundStyle(RunMileColor.foreground)
+        }
+    }
+}
+
+
+private struct HOFPosterShareCard: View {
+    let sample: HOFShareCardSample
+
+    var body: some View {
+        ZStack {
+            RunMileColor.secondary
+
+            VStack(alignment: .leading, spacing: 0) {
+                HOFShareTopLabel(text: "LEGENDARY SHOE")
+
+                Spacer()
+
+                HOFShareShoeMark(size: 142, fill: RunMileColor.card)
+                    .rotationEffect(.degrees(-8))
+                    .padding(.bottom, 18)
+
+                Text(sample.distance)
+                    .font(.system(size: 48, weight: .black))
+                    .foregroundStyle(RunMileColor.foreground)
+                    .lineLimit(1)
+                    .minimumScaleFactor(0.75)
+
+                Text(sample.nickname)
+                    .font(.title3)
+                    .fontWeight(.black)
+                    .foregroundStyle(RunMileColor.foreground)
+
+                Text(sample.model)
+                    .font(.caption)
+                    .fontWeight(.bold)
+                    .foregroundStyle(RunMileColor.mutedForeground)
+                    .lineLimit(2)
+
+                Spacer()
+
+                HStack {
+                    HOFShareSmallStat(title: "RUNS", value: sample.runs)
+                    Spacer()
+                    HOFShareSmallStat(title: "LONGEST", value: sample.longest)
+                }
+            }
+            .padding(24)
+        }
+    }
+}
+
+
+private struct HOFSplitShareCard: View {
+    let sample: HOFShareCardSample
+
+    var body: some View {
+        ZStack {
+            RunMileColor.foreground
+
+            VStack(alignment: .leading, spacing: 18) {
+                HStack {
+                    Text("HALL OF FAME")
+                        .font(.caption)
+                        .fontWeight(.black)
+                        .foregroundStyle(RunMileColor.secondary)
+                        .tracking(1.4)
+
+                    Spacer()
+
+                    Text(sample.goalRate)
+                        .font(.caption)
+                        .fontWeight(.black)
+                        .foregroundStyle(RunMileColor.secondaryForeground)
+                        .padding(.horizontal, 8)
+                        .padding(.vertical, 5)
+                        .background(RunMileColor.secondary)
+                }
+
+                Spacer()
+
+                Text(sample.distance)
+                    .font(.system(size: 46, weight: .black))
+                    .foregroundStyle(RunMileColor.card)
+                    .lineLimit(1)
+                    .minimumScaleFactor(0.72)
+
+                VStack(alignment: .leading, spacing: 8) {
+                    HOFShareMetricStripe(title: "TOTAL RUNS", value: sample.runs)
+                    HOFShareMetricStripe(title: "BEST PACE", value: sample.bestPace)
+                    HOFShareMetricStripe(title: "ACTIVE DAYS", value: sample.activeDays)
+                }
+
+                Spacer()
+
+                HOFShareShoeMark(size: 102, fill: RunMileColor.secondary)
+                    .rotationEffect(.degrees(-12))
+
+                Text(sample.nickname)
+                    .font(.title2)
+                    .fontWeight(.black)
+                    .foregroundStyle(RunMileColor.card)
+                    .lineLimit(1)
+            }
+            .padding(22)
+        }
+    }
+}
+
+
+private struct HOFOverlayShareCard: View {
+    let sample: HOFShareCardSample
+
+    var body: some View {
+        ZStack {
+            LinearGradient(
+                colors: [
+                    RunMileColor.accent,
+                    RunMileColor.secondary,
+                    RunMileColor.primary
+                ],
+                startPoint: .topLeading,
+                endPoint: .bottomTrailing
+            )
+
+            VStack(spacing: 18) {
+                Spacer()
+
+                VStack(alignment: .leading, spacing: 12) {
+                    Text("RUN MILE")
+                        .font(.caption2)
+                        .fontWeight(.black)
+                        .foregroundStyle(RunMileColor.primary)
+                        .tracking(1.4)
+
+                    Text(sample.nickname)
+                        .font(.title)
+                        .fontWeight(.black)
+                        .foregroundStyle(RunMileColor.foreground)
+                        .lineLimit(1)
+
+                    Text(sample.distance)
+                        .font(.system(size: 48, weight: .black))
+                        .foregroundStyle(RunMileColor.foreground)
+                        .lineLimit(1)
+                        .minimumScaleFactor(0.72)
+
+                    HStack(spacing: 10) {
+                        HOFShareOverlayPill(title: "RUNS", value: sample.runs)
+                        HOFShareOverlayPill(title: "PACE", value: sample.bestPace)
+                    }
+                }
+                .padding(18)
+                .background(.ultraThinMaterial)
+                .overlay {
+                    Rectangle()
+                        .stroke(RunMileColor.border, lineWidth: RunMileStroke.border)
+                }
+
+                Text("첫 풀코스를 함께 버틴 신발")
+                    .font(.caption)
+                    .fontWeight(.black)
+                    .foregroundStyle(RunMileColor.card)
+                    .padding(.horizontal, 12)
+                    .padding(.vertical, 8)
+                    .background(RunMileColor.foreground)
+
+                Spacer()
+            }
+            .padding(22)
+        }
+    }
+}
+
+
+private struct HOFReceiptShareCard: View {
+    let sample: HOFShareCardSample
+
+    var body: some View {
+        ZStack {
+            RunMileColor.card
+
+            VStack(alignment: .leading, spacing: 16) {
+                Text("GRADUATION REPORT")
+                    .font(.caption)
+                    .fontWeight(.black)
+                    .foregroundStyle(RunMileColor.primary)
+                    .tracking(1.4)
+
+                Text(sample.nickname)
+                    .font(.title)
+                    .fontWeight(.black)
+                    .foregroundStyle(RunMileColor.foreground)
+
+                Rectangle()
+                    .fill(RunMileColor.border)
+                    .frame(height: 3)
+
+                HOFShareReceiptRow(title: "TOTAL", value: sample.distance)
+                HOFShareReceiptRow(title: "RUNS", value: sample.runs)
+                HOFShareReceiptRow(title: "LONGEST", value: sample.longest)
+                HOFShareReceiptRow(title: "BEST PACE", value: sample.bestPace)
+                HOFShareReceiptRow(title: "GOAL", value: sample.goalRate)
+
+                Spacer()
+
+                HOFShareShoeMark(size: 94, fill: RunMileColor.secondary)
+                    .rotationEffect(.degrees(-8))
+
+                Text("THANKS FOR EVERY MILE")
+                    .font(.caption)
+                    .fontWeight(.black)
+                    .foregroundStyle(RunMileColor.mutedForeground)
+                    .tracking(1)
+            }
+            .padding(24)
+        }
+    }
+}
+
+
+private struct HOFTrophyShareCard: View {
+    let sample: HOFShareCardSample
+
+    var body: some View {
+        ZStack {
+            RunMileColor.primary
+
+            VStack(spacing: 18) {
+                Image(systemName: "laurel.leading")
+                    .font(.system(size: 72, weight: .black))
+                    .foregroundStyle(RunMileColor.secondary)
+
+                Text("LEGENDARY")
+                    .font(.caption)
+                    .fontWeight(.black)
+                    .foregroundStyle(RunMileColor.secondaryForeground)
+                    .padding(.horizontal, 12)
+                    .padding(.vertical, 7)
+                    .background(RunMileColor.secondary)
+                    .overlay {
+                        Rectangle()
+                            .stroke(RunMileColor.border, lineWidth: RunMileStroke.border)
+                    }
+
+                Spacer()
+
+                Text(sample.distance)
+                    .font(.system(size: 46, weight: .black))
+                    .foregroundStyle(RunMileColor.primaryForeground)
+                    .lineLimit(1)
+                    .minimumScaleFactor(0.72)
+
+                Text(sample.nickname)
+                    .font(.title2)
+                    .fontWeight(.black)
+                    .foregroundStyle(RunMileColor.primaryForeground)
+                    .lineLimit(1)
+
+                Text("\(sample.runs) · \(sample.activeDays)")
+                    .font(.headline)
+                    .fontWeight(.black)
+                    .foregroundStyle(RunMileColor.secondary)
+
+                Spacer()
+
+                HOFShareShoeMark(size: 116, fill: RunMileColor.card)
+                    .rotationEffect(.degrees(-10))
+            }
+            .padding(24)
+        }
+    }
+}
+
+
+private struct HOFShareTopLabel: View {
+    let text: String
+
+    var body: some View {
+        Text(text)
+            .font(.caption)
+            .fontWeight(.black)
+            .foregroundStyle(RunMileColor.primaryForeground)
+            .tracking(1.2)
+            .padding(.horizontal, 10)
+            .padding(.vertical, 7)
+            .background(RunMileColor.primary)
+            .overlay {
+                Rectangle()
+                    .stroke(RunMileColor.border, lineWidth: RunMileStroke.border)
+            }
+    }
+}
+
+
+private struct HOFShareShoeMark: View {
+    let size: CGFloat
+    let fill: Color
+
+    var body: some View {
+        Image(systemName: "shoe.fill")
+            .font(.system(size: size * 0.55, weight: .black))
+            .foregroundStyle(RunMileColor.foreground)
+            .frame(width: size, height: size)
+            .background(fill)
+            .overlay {
+                Rectangle()
+                    .stroke(RunMileColor.border, lineWidth: RunMileStroke.border)
+            }
+            .shadow(color: RunMileColor.border, radius: 0, x: 5, y: 5)
+    }
+}
+
+
+private struct HOFShareSmallStat: View {
+    let title: String
+    let value: String
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 3) {
+            Text(title)
+                .font(.caption2)
+                .fontWeight(.black)
+                .foregroundStyle(RunMileColor.mutedForeground)
+
+            Text(value)
+                .font(.headline)
+                .fontWeight(.black)
+                .foregroundStyle(RunMileColor.foreground)
+        }
+    }
+}
+
+
+private struct HOFShareMetricStripe: View {
+    let title: String
+    let value: String
+
+    var body: some View {
+        HStack {
+            Text(title)
+                .font(.caption2)
+                .fontWeight(.black)
+                .foregroundStyle(RunMileColor.foreground)
+
+            Spacer()
+
+            Text(value)
+                .font(.caption)
+                .fontWeight(.black)
+                .foregroundStyle(RunMileColor.foreground)
+        }
+        .padding(.horizontal, 10)
+        .padding(.vertical, 8)
+        .background(RunMileColor.card)
+        .overlay {
+            Rectangle()
+                .stroke(RunMileColor.border, lineWidth: RunMileStroke.hairline)
+        }
+    }
+}
+
+
+private struct HOFShareOverlayPill: View {
+    let title: String
+    let value: String
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 3) {
+            Text(title)
+                .font(.caption2)
+                .fontWeight(.black)
+                .foregroundStyle(RunMileColor.mutedForeground)
+
+            Text(value)
+                .font(.caption)
+                .fontWeight(.black)
+                .foregroundStyle(RunMileColor.foreground)
+        }
+        .frame(maxWidth: .infinity, alignment: .leading)
+    }
+}
+
+
+private struct HOFShareReceiptRow: View {
+    let title: String
+    let value: String
+
+    var body: some View {
+        HStack(alignment: .firstTextBaseline) {
+            Text(title)
+                .font(.caption)
+                .fontWeight(.black)
+                .foregroundStyle(RunMileColor.mutedForeground)
+
+            Spacer()
+
+            Text(value)
+                .font(.headline)
+                .fontWeight(.black)
+                .foregroundStyle(RunMileColor.foreground)
+                .lineLimit(1)
+                .minimumScaleFactor(0.72)
+        }
+    }
+}
+
+
+private struct HOFShareNote: View {
+    let title: String
+    let description: String
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 4) {
+            Text(title)
+                .font(.subheadline)
+                .fontWeight(.black)
+                .foregroundStyle(RunMileColor.foreground)
+
+            Text(description)
+                .font(.caption)
+                .fontWeight(.semibold)
+                .foregroundStyle(RunMileColor.mutedForeground)
+                .fixedSize(horizontal: false, vertical: true)
+        }
+    }
+}
+
+
+private struct HOFShareCardSample {
+    let nickname: String
+    let model: String
+    let distance: String
+    let runs: String
+    let longest: String
+    let bestPace: String
+    let goalRate: String
+    let activeDays: String
+
+    static let sample = HOFShareCardSample(
+        nickname: "첫 풀코스",
+        model: "Adidas Adizero Adios Pro 3",
+        distance: "642.8KM",
+        runs: "83 RUNS",
+        longest: "21.1KM",
+        bestPace: "4'52\"",
+        goalRate: "107%",
+        activeDays: "176 DAYS"
+    )
+}
+
+
+#Preview("HOF Share Card Variants") {
+    NavigationStack {
+        HOFShareCardVariantsPreviewView()
+    }
+}


### PR DESCRIPTION
close #75

## Summary
이 PR은 Hall of Fame(HOF) 피쳐를 고도화해 사용자가 자신의 러닝 기록과 신발 사용 이력을 더 풍부하게 회고할 수 있도록 개선했습니다. HOF 리포트 화면과 ViewModel을 추가하고, 운동 거리 구간 기록을 계산/캐싱하는 도메인 및 데이터 계층을 보강했습니다.

## Key Changes

### 1. HOF Report 화면 추가
- `HOFReportView`와 `HOFReportViewModel`을 추가해 HOF 상세 리포트 화면을 구성했습니다.
- `HOFReportComponents`를 추가해 리포트 카드, 공유 카드 등 HOF 리포트 UI 요소를 컴포넌트화했습니다.
- HOF 화면과 NavigationCoordinator를 수정해 HOF 리포트로 이동할 수 있는 흐름을 연결했습니다.

### 2. Workout Distance Record 계산 도입
- `WorkoutDistanceRecord` 엔티티와 target 모델을 추가해 1K/3K/5K 등 거리별 기록 데이터를 표현할 수 있도록 했습니다.
- `HOFUseCase`를 확장해 전체 러닝 운동을 가져오고, HealthKit distance samples 기반으로 거리 구간별 최고 기록을 계산하도록 구현했습니다.
- pause/resume 이벤트를 고려해 active duration 기준으로 기록을 계산하도록 처리했습니다.

### 3. Distance Record Cache Repository 추가
- `WorkoutDistanceRecordCacheRepository` 인터페이스와 `WorkoutDistanceRecordCacheRepositoryImpl`을 추가했습니다.
- 운동별 거리 기록 계산 결과를 캐싱해 동일 운동에 대한 반복 계산을 줄일 수 있도록 했습니다.
- `AppDIContainer`, `ScreenDependencyProviding`, Preview DI 구성을 업데이트해 신규 HOF 의존성을 주입하도록 정리했습니다.

### 4. Preview & Data Support
- `HOFReportDataPreviewView`, `HOFShareCardVariantsPreviewView`를 추가해 HOF 리포트 UI 상태를 Preview에서 확인할 수 있도록 했습니다.
- `PreviewMyPageUseCases`를 보강해 HOF 리포트 관련 preview 데이터를 제공하도록 수정했습니다.
- `WorkoutDataRepository`와 `WorkoutDataRepositoryImpl`을 확장해 거리 샘플 조회 흐름을 지원했습니다.

## Impact
- HOF 화면이 단순 신발 목록을 넘어 러닝 기록 리포트와 성과 회고 화면으로 확장됩니다.
- 사용자는 운동별 거리 구간 기록과 HOF 관련 데이터를 더 풍부하게 확인할 수 있습니다.
- 거리 기록 계산과 캐싱이 분리되어 HOF 리포트 기능을 확장하기 쉬운 구조가 됩니다.

## Validation
- 변경 사항은 커밋 기록과 `origin/develop...HEAD` diff 기준으로 확인했습니다.
- 로컬 빌드/테스트는 별도로 실행하지 않았습니다.