### PR TITLE
[Fix] QA 사항 수정

### DIFF
--- a/Run Mile/App/Core/AppDIContainer.swift
+++ b/Run Mile/App/Core/AppDIContainer.swift
@@ -85,12 +85,16 @@ final class AppDIContainer: ScreenDependencyProviding {
     }
     
     /// 운동 기록을 신발에 연결하는 화면의 ViewModel을 생성합니다.
-    func makeChooseShoesViewModel(workouts: [Workout]) -> ChooseShoesViewModel {
+    func makeChooseShoesViewModel(
+        workouts: [Workout],
+        dismissAction: @escaping () -> Void
+    ) -> ChooseShoesViewModel {
         ChooseShoesViewModel(
             useCase: DefaultChooseShoesUseCase(
                 repository: shoesRepository
             ),
-            workouts: workouts
+            workouts: workouts,
+            dismissAction: dismissAction
         )
     }
     

--- a/Run Mile/App/Core/Preview/PreviewDIContainer.swift
+++ b/Run Mile/App/Core/Preview/PreviewDIContainer.swift
@@ -71,10 +71,14 @@ final class PreviewDIContainer: ScreenDependencyProviding {
     }
     
     /// 신발 선택 Sheet Preview용 ViewModel을 샘플 신발 목록이 채워진 상태로 생성합니다.
-    func makeChooseShoesViewModel(workouts: [Workout]) -> ChooseShoesViewModel {
+    func makeChooseShoesViewModel(
+        workouts: [Workout],
+        dismissAction: @escaping () -> Void = {}
+    ) -> ChooseShoesViewModel {
         let viewModel = ChooseShoesViewModel(
             useCase: PreviewChooseShoesUseCase(),
-            workouts: workouts
+            workouts: workouts,
+            dismissAction: dismissAction
         )
         viewModel.shoes = PreviewShoesMockData.shoes
         viewModel.selectedShoe = PreviewShoesMockData.shoes.first

--- a/Run Mile/App/Core/Preview/PreviewShoesMockData.swift
+++ b/Run Mile/App/Core/Preview/PreviewShoesMockData.swift
@@ -61,7 +61,8 @@ enum PreviewShoesMockData {
             goalMileage: 600,
             currentMileage: 624,
             workouts: Array(workouts.prefix(2)),
-            isGraduate: true
+            isGraduate: true,
+            graduatedAt: referenceDate.addingTimeInterval(-2 * 24 * 60 * 60)
         ),
         Shoes(
             id: UUID(uuidString: "E947029C-C831-4DE8-9444-925C1B2F3D5F") ?? UUID(),
@@ -71,7 +72,8 @@ enum PreviewShoesMockData {
             goalMileage: 700,
             currentMileage: 732,
             workouts: Array(workouts.suffix(2)),
-            isGraduate: true
+            isGraduate: true,
+            graduatedAt: referenceDate.addingTimeInterval(-14 * 24 * 60 * 60)
         )
     ]
     

--- a/Run Mile/App/Core/Preview/PreviewWorkoutUseCases.swift
+++ b/Run Mile/App/Core/Preview/PreviewWorkoutUseCases.swift
@@ -15,12 +15,12 @@ struct PreviewHealthDataUseCase: HealthDataUseCase {
     func checkHealthAuthorization() async throws -> Bool {
         false
     }
-    
+
     /// 운동 목록 Preview에 사용할 샘플 운동 데이터를 반환합니다.
     func fetchWorkoutData() async throws -> [Workout] {
         PreviewShoesMockData.workouts
     }
-    
+
     /// 운동 목록 Preview에 사용할 운동-신발 등록 정보를 반환합니다.
     func fetchWorkoutShoeNames() async throws -> [UUID: String] {
         PreviewWorkoutMockData.workoutShoeNames
@@ -36,7 +36,7 @@ struct PreviewWorkoutDetailUseCase: WorkoutDetailUseCase {
     ) async throws -> WorkoutDetailData {
         PreviewWorkoutMockData.detail
     }
-    
+
     /// Preview 데이터는 이미 표시용으로 적당히 줄어든 상태라 원본을 반환합니다.
     func downsampling(
         samples: [UnifiedWorkoutDetailData],
@@ -44,7 +44,7 @@ struct PreviewWorkoutDetailUseCase: WorkoutDetailUseCase {
     ) -> [UnifiedWorkoutDetailData] {
         samples
     }
-    
+
     /// Preview 지도에 사용할 페이스 구간을 위치 배열 기반으로 간단히 생성합니다.
     func buildRouteSegments(
         locations: [CLLocation],
@@ -52,7 +52,7 @@ struct PreviewWorkoutDetailUseCase: WorkoutDetailUseCase {
         workoutStartDate: Date
     ) -> [WorkoutRouteSegment] {
         guard locations.count >= 2 else { return [] }
-        
+
         return zip(locations, locations.dropFirst()).enumerated().map { index, pair in
             let ratio = Double(index) / Double(max(locations.count - 2, 1))
             return WorkoutRouteSegment(
@@ -70,25 +70,34 @@ struct PreviewChooseShoesUseCase: ChooseShoesUseCase {
     func fetchShoesList() async throws -> [Shoes] {
         PreviewShoesMockData.shoes
     }
-    
+
+    /// Preview에서는 이미 등록된 운동 충돌이 없는 상태로 표시합니다.
+    func registeredWorkoutConflictCount(targetShoes: Shoes, workouts: [Workout]) async throws -> Int {
+        0
+    }
+
     /// Preview에서는 저장소를 변경하지 않고 등록 완료 흐름만 통과시킵니다.
-    func registerWorkouts(shoes: Shoes, workouts: [Workout]) async throws {}
+    func registerWorkouts(
+        shoes: Shoes,
+        workouts: [Workout],
+        shouldMoveRegisteredWorkouts: Bool
+    ) async throws {}
 }
 
 
 struct PreviewAddMileageShoesUseCase: AddMileageShoesUseCase {
     private let selectedShoesId: UUID? = PreviewShoesMockData.shoes.first?.id
-    
+
     /// 자동 등록 Preview에 사용할 샘플 신발 목록을 반환합니다.
     func fetchAllShoes() async throws -> [Shoes] {
         PreviewShoesMockData.shoes
     }
-    
+
     /// 자동 등록 Preview에서 선택된 신발 ID를 반환합니다.
     func fetchCurrentSelectedSheos() -> UUID? {
         selectedShoesId
     }
-    
+
     /// Preview에서는 UserDefaults를 변경하지 않습니다.
     func setCurrentSelectedShoes(id: UUID?) {}
 }

--- a/Run Mile/App/Core/ScreenDependencyProviding.swift
+++ b/Run Mile/App/Core/ScreenDependencyProviding.swift
@@ -14,7 +14,7 @@ protocol ScreenDependencyProviding {
     func makeAddShoesViewModel() -> AddShoesViewModel
     func makeWorkoutListViewModel() -> WorkoutListViewModel
     func makeWorkoutDetailViewModel(workout: Workout) -> WorkoutDetailViewModel
-    func makeChooseShoesViewModel(workouts: [Workout]) -> ChooseShoesViewModel
+    func makeChooseShoesViewModel(workouts: [Workout], dismissAction: @escaping () -> Void) -> ChooseShoesViewModel
     func makeAutoMileageShoesViewModel() -> AutoMileageShoesViewModel
     func makeMyPageViewModel() -> MyPageViewModel
     func makeHOFViewModel() -> HOFViewModel

--- a/Run Mile/App/Core/ScreenFactory.swift
+++ b/Run Mile/App/Core/ScreenFactory.swift
@@ -61,8 +61,10 @@ struct ScreenFactory {
             )
         case let .chooseShoes(workouts, action):
             ChooseShoesView(
-                viewModel: container.makeChooseShoesViewModel(workouts: workouts),
-                dismiss: action
+                viewModel: container.makeChooseShoesViewModel(
+                    workouts: workouts,
+                    dismissAction: action
+                )
             )
             .presentationDetents([.medium, .large])
             .presentationDragIndicator(.hidden)

--- a/Run Mile/App/Core/Services/HealthBackgroundSyncService.swift
+++ b/Run Mile/App/Core/Services/HealthBackgroundSyncService.swift
@@ -36,11 +36,11 @@ final class DefaultHealthBackgroundSyncService: HealthBackgroundSyncService {
     private let healthStore = HKHealthStore()
     private let shoesRepository: ShoesDataRepository
     private var workoutObserverQuery: HKObserverQuery?
-    
+
     init(shoesRepository: ShoesDataRepository) {
         self.shoesRepository = shoesRepository
     }
-    
+
     /// 백그라운드에서 HealthKit workout 변경을 받을 수 있도록 등록합니다.
     func enableBackgroundDelivery() async {
         do {
@@ -49,15 +49,15 @@ final class DefaultHealthBackgroundSyncService: HealthBackgroundSyncService {
             print(error.localizedDescription)
         }
     }
-    
+
     /// HealthKit workout 변경 감지를 위한 observer query를 등록합니다.
     func registerHealthBackgroundQueryTask() {
         if let workoutObserverQuery {
             healthStore.stop(workoutObserverQuery)
         }
-        
+
         prepareWorkoutAnchorIfNeeded()
-        
+
         let observerQuery = HKObserverQuery(
             sampleType: .workoutType(),
             predicate: nil
@@ -66,58 +66,71 @@ final class DefaultHealthBackgroundSyncService: HealthBackgroundSyncService {
                 completionHandler()
                 return
             }
-            
+
             if let error {
                 print(error.localizedDescription)
                 completionHandler()
                 return
             }
-            
+
             self.fetchUpdatedWorkouts {
                 completionHandler()
             }
         }
-        
+
         self.workoutObserverQuery = observerQuery
         healthStore.execute(observerQuery)
     }
-    
+
     /// 이전 백그라운드 실행에서 완료하지 못한 workout 처리를 앱 실행 시 재시도합니다.
     func processPendingRunningWorkoutsIfNeeded() async {
         let pendingIDs = UserDefaults.standard.pendingRunningWorkoutIDs
         guard !pendingIDs.isEmpty else {
             return
         }
-        
+
         var workouts: [HKWorkout] = []
+        var removablePendingIDs = Set<String>()
         for id in pendingIDs {
-            guard let uuid = UUID(uuidString: id) else { continue }
-            
+            guard let uuid = UUID(uuidString: id) else {
+                removablePendingIDs.insert(id)
+                continue
+            }
+
             do {
                 if let workout = try await healthStore.fetchSingleWorkoutData(id: uuid),
                    workout.workoutActivityType == .running {
                     workouts.append(workout)
+                } else {
+                    removablePendingIDs.insert(id)
                 }
             } catch {
                 print(error.localizedDescription)
             }
         }
-        
+
+        if !removablePendingIDs.isEmpty {
+            UserDefaults.standard.pendingRunningWorkoutIDs = Self.remainingPendingRunningWorkoutIDs(
+                currentIDs: pendingIDs,
+                removingIDs: removablePendingIDs
+            )
+        }
+
         guard !workouts.isEmpty else {
             return
         }
-        
+
         await processUpdatedRunningWorkouts(workouts)
         removePendingRunningWorkouts(workouts)
     }
-    
+
     /// HealthKit에 저장된 러닝 workout을 UUID로 조회해 앱 도메인 모델로 변환합니다.
     func fetchRunningWorkout(id: UUID) async throws -> Workout? {
         guard let workout = try await healthStore.fetchSingleWorkoutData(id: id),
               workout.workoutActivityType == .running else {
             return nil
         }
-        
+
         return Workout(workout: workout)
     }
 }
@@ -129,7 +142,7 @@ private extension DefaultHealthBackgroundSyncService {
         guard UserDefaults.standard.lastAnchor == nil else {
             return
         }
-        
+
         let query = HKAnchoredObjectQuery(
             type: .workoutType(),
             predicate: nil,
@@ -140,15 +153,15 @@ private extension DefaultHealthBackgroundSyncService {
                 print(error.localizedDescription)
                 return
             }
-            
+
             if let anchor {
                 UserDefaults.standard.lastAnchor = anchor
             }
         }
-        
+
         healthStore.execute(query)
     }
-    
+
     /// ObserverQuery가 감지한 HealthKit 변경분을 AnchoredObjectQuery로 가져옵니다.
     func fetchUpdatedWorkouts(completion: @escaping () -> Void) {
         guard let currentAnchor = UserDefaults.standard.lastAnchor else {
@@ -156,7 +169,7 @@ private extension DefaultHealthBackgroundSyncService {
             completion()
             return
         }
-        
+
         let query = HKAnchoredObjectQuery(
             type: .workoutType(),
             predicate: nil,
@@ -167,63 +180,64 @@ private extension DefaultHealthBackgroundSyncService {
                 completion()
                 return
             }
-            
+
             if let error {
                 print(error.localizedDescription)
                 completion()
                 return
             }
-            
+
             let workouts = (samples as? [HKWorkout]) ?? []
             let runningWorkouts = workouts.filter {
                 $0.workoutActivityType == .running
             }
-            
+
             guard !runningWorkouts.isEmpty else {
                 if let anchor {
                     UserDefaults.standard.lastAnchor = anchor
                 }
-                
+
                 completion()
                 return
             }
-            
+
             enqueuePendingRunningWorkouts(runningWorkouts)
-            
+
             if let anchor {
                 UserDefaults.standard.lastAnchor = anchor
             }
-            
+
             completion()
-            
+
             Task {
                 await self.processUpdatedRunningWorkouts(runningWorkouts)
                 self.removePendingRunningWorkouts(runningWorkouts)
             }
         }
-        
+
         healthStore.execute(query)
     }
-    
+
     /// 백그라운드 실행 시간이 부족할 때를 대비해 처리 예정 workout UUID를 먼저 저장합니다.
     func enqueuePendingRunningWorkouts(_ workouts: [HKWorkout]) {
         let newIDs = workouts.map { $0.uuid.uuidString }
         let currentIDs = UserDefaults.standard.pendingRunningWorkoutIDs
         let mergedIDs = Array(Set(currentIDs + newIDs))
-        
+
         UserDefaults.standard.pendingRunningWorkoutIDs = mergedIDs
     }
-    
+
     /// 처리가 끝난 workout UUID를 pending 목록에서 제거합니다.
     func removePendingRunningWorkouts(_ workouts: [HKWorkout]) {
         let processedIDs = Set(workouts.map { $0.uuid.uuidString })
-        let remainingIDs = UserDefaults.standard.pendingRunningWorkoutIDs.filter {
-            !processedIDs.contains($0)
-        }
-        
+        let remainingIDs = Self.remainingPendingRunningWorkoutIDs(
+            currentIDs: UserDefaults.standard.pendingRunningWorkoutIDs,
+            removingIDs: processedIDs
+        )
+
         UserDefaults.standard.pendingRunningWorkoutIDs = remainingIDs
     }
-    
+
     /// 새로 추가된 러닝 운동들을 자동 등록 설정에 따라 처리합니다.
     func processUpdatedRunningWorkouts(_ workouts: [HKWorkout]) async {
         for workout in workouts {
@@ -234,23 +248,23 @@ private extension DefaultHealthBackgroundSyncService {
             }
         }
     }
-    
+
     /// 업데이트된 운동을 현재 자동 등록 신발에 연결합니다.
     func autoRegisterShoes(workout: HKWorkout) async {
         let newWorkout = Workout(workout: workout)
-        
+
         do {
             guard let shoesID = UUID(uuidString: UserDefaults.standard.selectedShoesID) else {
                 requestManualRegisterNotification(workout: workout)
                 return
             }
-            
+
             let shoes = try await shoesRepository.fetchSingleShoes(id: shoesID)
-            
+
             guard !shoes.workouts.contains(where: { $0.id == newWorkout.id }) else {
                 return
             }
-            
+
             let newShoes = Shoes(
                 id: shoes.id,
                 image: shoes.image,
@@ -260,7 +274,7 @@ private extension DefaultHealthBackgroundSyncService {
                 currentMileage: shoes.currentMileage,
                 workouts: shoes.workouts + [newWorkout]
             )
-            
+
             try await shoesRepository.updateShoes(shoes: newShoes)
             requestAutoRegisterNotification(workout: workout, shoesName: shoesNotificationName(for: shoes))
         } catch {
@@ -271,7 +285,7 @@ private extension DefaultHealthBackgroundSyncService {
             )
         }
     }
-    
+
     /// 자동 등록 성공 후 사용자에게 완료 알림을 보냅니다.
     func requestAutoRegisterNotification(workout: HKWorkout, shoesName: String) {
         UserNotificationsManager.requestNotification(
@@ -280,29 +294,40 @@ private extension DefaultHealthBackgroundSyncService {
             body: "\(shoesName)에 마일리지가 자동으로 추가됐어요."
         )
     }
-    
+
     /// 자동 등록 신발이 없을 때 수동 등록 안내 알림을 보냅니다.
     func requestManualRegisterNotification(workout: HKWorkout) {
         let entity = Workout(workout: workout)
-        
+
         UserNotificationsManager.requestNotification(
             category: .manualRegister(entity),
             title: notificationTitle(for: workout),
             body: "오늘 함께 달린 신발을 선택해 마일리지를 기록해요."
         )
     }
-    
+
     /// 러닝 완료 노티에서 공통으로 사용할 거리 기반 제목을 생성합니다.
     func notificationTitle(for workout: HKWorkout) -> String {
         guard let distance = workout.getKilometerDistance() else {
             return "러닝 완료🔥"
         }
-        
+
         return String(format: "%.2fkm 러닝 완료🔥", distance)
     }
-    
+
     /// 자동 등록 노티에 표시할 신발 이름을 결정합니다.
     func shoesNotificationName(for shoes: Shoes) -> String {
         shoes.shoesName.isEmpty ? shoes.nickname : shoes.shoesName
+    }
+}
+
+
+extension DefaultHealthBackgroundSyncService {
+    /// pending 목록에서 처리 완료 또는 더 이상 유효하지 않은 workout UUID를 제거합니다.
+    static func remainingPendingRunningWorkoutIDs(
+        currentIDs: [String],
+        removingIDs: Set<String>
+    ) -> [String] {
+        currentIDs.filter { !removingIDs.contains($0) }
     }
 }

--- a/Run Mile/Data/CoreData/CoreDataManager.swift
+++ b/Run Mile/Data/CoreData/CoreDataManager.swift
@@ -13,6 +13,10 @@ final class CoreDataManager {
 
     lazy var persistentContainer: NSPersistentContainer = {
         let container = NSPersistentContainer(name: "RunMileModel") // .xcdatamodeld 파일 이름
+        container.persistentStoreDescriptions.forEach {
+            $0.shouldMigrateStoreAutomatically = true
+            $0.shouldInferMappingModelAutomatically = true
+        }
         container.loadPersistentStores { _, error in
             if let error = error {
                 fatalError("Core Data Store 로드 실패: \(error)")

--- a/Run Mile/Data/CoreData/CoreDataManager.swift
+++ b/Run Mile/Data/CoreData/CoreDataManager.swift
@@ -10,7 +10,7 @@ import CoreData
 
 final class CoreDataManager {
     static let shared: CoreDataManager = .init()
-    
+
     lazy var persistentContainer: NSPersistentContainer = {
         let container = NSPersistentContainer(name: "RunMileModel") // .xcdatamodeld 파일 이름
         container.loadPersistentStores { _, error in
@@ -18,18 +18,20 @@ final class CoreDataManager {
                 fatalError("Core Data Store 로드 실패: \(error)")
             }
         }
+        container.viewContext.automaticallyMergesChangesFromParent = true
+        container.viewContext.mergePolicy = NSMergePolicy.mergeByPropertyObjectTrump
         return container
     }()
-    
+
     public var context: NSManagedObjectContext {
         return persistentContainer.viewContext
     }
-    
+
     // 백그라운드 작업을 위한 컨텍스트
     public var backgroundContext: NSManagedObjectContext {
         return persistentContainer.newBackgroundContext()
     }
-    
+
     public func saveContext() {
         if context.hasChanges {
             try? context.save()

--- a/Run Mile/Data/CoreData/RunMileModel.xcdatamodeld/RunMileModel.xcdatamodel/contents
+++ b/Run Mile/Data/CoreData/RunMileModel.xcdatamodeld/RunMileModel.xcdatamodel/contents
@@ -3,6 +3,7 @@
     <entity name="CDShoesDTO" representedClassName="CDShoesDTO" syncable="YES" codeGenerationType="class">
         <attribute name="createdAt" attributeType="Date" usesScalarValueType="NO"/>
         <attribute name="currentMileage" attributeType="Double" defaultValueString="0.0" usesScalarValueType="YES"/>
+        <attribute name="graduatedAt" optional="YES" attributeType="Date" usesScalarValueType="NO"/>
         <attribute name="goalMileage" attributeType="Double" defaultValueString="0.0" usesScalarValueType="YES"/>
         <attribute name="id" attributeType="UUID" usesScalarValueType="NO"/>
         <attribute name="image" attributeType="Binary"/>

--- a/Run Mile/Data/DTO/Mapper.swift
+++ b/Run Mile/Data/DTO/Mapper.swift
@@ -40,7 +40,8 @@ enum DTOMapper {
                 goalMileage: shoe.goalMileage,
                 currentMileage: shoe.currentMileage,
                 workouts: workouts,
-                isGraduate: shoe.isGraduated
+                isGraduate: shoe.isGraduated,
+                graduatedAt: shoe.graduatedAt
             )
             
             resultArray.append(result)

--- a/Run Mile/Data/Shoes/ShoesDataRepositoryImpl.swift
+++ b/Run Mile/Data/Shoes/ShoesDataRepositoryImpl.swift
@@ -26,9 +26,10 @@ actor ShoesDataRepositoryImpl: ShoesDataRepository {
 
     public func fetchHOFShoes() async throws -> [Shoes] {
         let request: NSFetchRequest<CDShoesDTO> = CDShoesDTO.fetchRequest()
+        request.predicate = NSPredicate(format: "isGraduated == YES")
         let results = try CoreDataManager.shared.context.fetch(request)
 
-        return try await DTOMapper.CDShoesDTOToEntities(results.filter({ $0.isGraduated }))
+        return try await DTOMapper.CDShoesDTOToEntities(results)
     }
 
     public func fetchSingleShoes(id: UUID) async throws -> Shoes {
@@ -56,6 +57,7 @@ actor ShoesDataRepositoryImpl: ShoesDataRepository {
             CDShoes.goalMileage = shoes.goalMileage
             CDShoes.currentMileage = shoes.currentMileage
             CDShoes.isGraduated = false
+            CDShoes.graduatedAt = nil
 
             try context.save()
         }
@@ -77,7 +79,13 @@ actor ShoesDataRepositoryImpl: ShoesDataRepository {
                 entity.nickname = shoes.nickname
                 entity.goalMileage = shoes.goalMileage
                 entity.currentMileage = shoes.currentMileage
+
                 entity.isGraduated = shoes.isGradutate
+                if shoes.isGradutate {
+                    entity.graduatedAt = shoes.graduatedAt ?? entity.graduatedAt ?? Date()
+                } else {
+                    entity.graduatedAt = nil
+                }
 
                 let existingWorkouts = (entity.workouts as? Set<CDWorkoutDTO>) ?? []
                 var workoutMap = Dictionary<UUID, CDWorkoutDTO>(

--- a/Run Mile/Data/Shoes/ShoesDataRepositoryImpl.swift
+++ b/Run Mile/Data/Shoes/ShoesDataRepositoryImpl.swift
@@ -22,30 +22,30 @@ actor ShoesDataRepositoryImpl: ShoesDataRepository {
         
         return try await DTOMapper.CDShoesDTOToEntities(results.filter({ !$0.isGraduated }))
     }
-    
-    
+
+
     public func fetchHOFShoes() async throws -> [Shoes] {
         let request: NSFetchRequest<CDShoesDTO> = CDShoesDTO.fetchRequest()
         let results = try CoreDataManager.shared.context.fetch(request)
-        
+
         return try await DTOMapper.CDShoesDTOToEntities(results.filter({ $0.isGraduated }))
     }
-    
+
     public func fetchSingleShoes(id: UUID) async throws -> Shoes {
         let request: NSFetchRequest<CDShoesDTO> = CDShoesDTO.fetchRequest()
         request.predicate = NSPredicate(format: "id == %@", id as CVarArg)
         let result = try CoreDataManager.shared.context.fetch(request)
-        
+
         if let entity = try await DTOMapper.CDShoesDTOToEntities(result).first {
             return entity
         } else {
             throw RepositoryError.fetchFailed
         }
     }
-    
+
     public func createShoes(shoes: Shoes) async throws {
         let context = CoreDataManager.shared.backgroundContext
-        
+
         try await context.perform {
             let CDShoes = CDShoesDTO(context: context)
             CDShoes.id = UUID()
@@ -56,21 +56,21 @@ actor ShoesDataRepositoryImpl: ShoesDataRepository {
             CDShoes.goalMileage = shoes.goalMileage
             CDShoes.currentMileage = shoes.currentMileage
             CDShoes.isGraduated = false
-            
+
             try context.save()
         }
     }
-    
+
     public func updateShoes(shoes: Shoes) async throws {
         let context = CoreDataManager.shared.backgroundContext
         context.mergePolicy = NSMergePolicy.mergeByPropertyObjectTrump
-        
+
         try await context.perform {
             let request: NSFetchRequest<CDShoesDTO> = CDShoesDTO.fetchRequest()
             request.predicate = NSPredicate(format: "id == %@", shoes.id as CVarArg)
             let result = try context.fetch(request)
-            
-            
+
+
             if let entity = result.first {
                 entity.image = shoes.image
                 entity.shoesName = shoes.shoesName
@@ -78,7 +78,7 @@ actor ShoesDataRepositoryImpl: ShoesDataRepository {
                 entity.goalMileage = shoes.goalMileage
                 entity.currentMileage = shoes.currentMileage
                 entity.isGraduated = shoes.isGradutate
-                
+
                 let existingWorkouts = (entity.workouts as? Set<CDWorkoutDTO>) ?? []
                 var workoutMap = Dictionary<UUID, CDWorkoutDTO>(
                     uniqueKeysWithValues: existingWorkouts.compactMap { entity in
@@ -86,10 +86,10 @@ actor ShoesDataRepositoryImpl: ShoesDataRepository {
                         return (id, entity) // Key: UUID, Value: Entity
                     }
                 )
-                
+
                 for workoutModel in shoes.workouts {
                     let workoutEntity: CDWorkoutDTO
-                    
+
                     if let existing = workoutMap[workoutModel.id] {
                         // A. 이미 존재하면 -> 가져오고, Map에서 제거 (처리됨 표시)
                         workoutEntity = existing
@@ -101,49 +101,103 @@ actor ShoesDataRepositoryImpl: ShoesDataRepository {
                         // 관계 연결 (중요)
                         workoutEntity.shoes = entity
                     }
-                    
+
                     // 속성 업데이트 (공통)
                     workoutEntity.distance = workoutModel.distance
                     workoutEntity.date = workoutModel.date
                 }
-                
+
                 for orphanedEntity in workoutMap.values {
                     context.delete(orphanedEntity)
                 }
             }
-            
+
             if !shoes.isGradutate, shoes.isOverGoal {
                 UserNotificationsManager.requestNotification(
                     title: "\(shoes.nickname)의 목표 마일리지를 달성했습니다!",
                     body: "축하드립니다! 이제 명예의 전당으로 갈 일만 남았습니다. 가보실까요?"
                 )
             }
-            
+
             if context.hasChanges {
                 try context.save()
             }
         }
     }
-    
+
+    public func registerWorkouts(
+        shoes: Shoes,
+        workouts: [Workout],
+        shouldMoveRegisteredWorkouts: Bool
+    ) async throws {
+        let context = CoreDataManager.shared.backgroundContext
+        context.mergePolicy = NSMergePolicy.mergeByPropertyObjectTrump
+
+        try await context.perform {
+            let targetShoesRequest: NSFetchRequest<CDShoesDTO> = CDShoesDTO.fetchRequest()
+            targetShoesRequest.predicate = NSPredicate(format: "id == %@", shoes.id as CVarArg)
+
+            guard let targetShoes = try context.fetch(targetShoesRequest).first else {
+                throw RepositoryError.fetchFailed
+            }
+
+            for workout in workouts {
+                let workoutRequest: NSFetchRequest<CDWorkoutDTO> = CDWorkoutDTO.fetchRequest()
+                workoutRequest.predicate = NSPredicate(format: "id == %@", workout.id as CVarArg)
+                let existingWorkouts = try context.fetch(workoutRequest)
+
+                let workoutEntity = existingWorkouts.first { $0.shoes?.id == targetShoes.id } ?? existingWorkouts.first
+
+                if let workoutEntity {
+                    let canAttachToTarget = shouldMoveRegisteredWorkouts ||
+                        workoutEntity.shoes?.id == targetShoes.id ||
+                        workoutEntity.shoes == nil
+
+                    guard canAttachToTarget else {
+                        continue
+                    }
+
+                    workoutEntity.shoes = targetShoes
+                    workoutEntity.distance = workout.distance
+                    workoutEntity.date = workout.date
+
+                    for duplicate in existingWorkouts where duplicate.objectID != workoutEntity.objectID {
+                        context.delete(duplicate)
+                    }
+                } else {
+                    let workoutEntity = CDWorkoutDTO(context: context)
+                    workoutEntity.id = workout.id
+                    workoutEntity.distance = workout.distance
+                    workoutEntity.date = workout.date
+                    workoutEntity.shoes = targetShoes
+                }
+            }
+
+            if context.hasChanges {
+                try context.save()
+            }
+        }
+    }
+
     public func deleteShoes(shoes: Shoes) async throws {
         let context = CoreDataManager.shared.backgroundContext
-        
+
         try await context.perform {
             let request: NSFetchRequest<CDShoesDTO> = CDShoesDTO.fetchRequest()
             request.predicate = NSPredicate(format: "id == %@", shoes.id as CVarArg)
-            
+
             let fetchedResult = try context.fetch(request)
-            
+
             if let entityToDelete = fetchedResult.first {
                 context.delete(entityToDelete)
             }
-            
+
             if context.hasChanges {
                 try context.save()
             }
         }
     }
-    
+
     public func updateSelectedShoes(shoes: Shoes) async {
         if UserDefaults.standard.selectedShoesID == shoes.id.uuidString {
             UserDefaults.standard.selectedShoesID = ""

--- a/Run Mile/Domain/Entities/Shoes.swift
+++ b/Run Mile/Domain/Entities/Shoes.swift
@@ -18,6 +18,7 @@ struct Shoes: Sendable, Identifiable, Hashable {
     let isCurrentShoes: Bool            // 현재 자동등록이 선택된 신발인지 여부
     var workouts: [Workout]         // 신발에 등록된 운동기록
     let isGradutate: Bool               // 신발 졸업 여부
+    let graduatedAt: Date?              // 신발 졸업 일시
     
     init(id: UUID,
          image: Data,
@@ -26,7 +27,8 @@ struct Shoes: Sendable, Identifiable, Hashable {
          goalMileage: Double,
          currentMileage: Double,
          workouts: [Workout],
-         isGraduate: Bool = false
+         isGraduate: Bool = false,
+         graduatedAt: Date? = nil
     ) {
         self.id = id
         self.image = image
@@ -36,6 +38,7 @@ struct Shoes: Sendable, Identifiable, Hashable {
         self.currentMileage = currentMileage
         self.workouts = workouts
         self.isGradutate = isGraduate
+        self.graduatedAt = graduatedAt
         
         // 현재 자동 등록이 된 신발인지 여부 판단
         self.isCurrentShoes = UserDefaults.standard.selectedShoesID == id.uuidString

--- a/Run Mile/Domain/Interfaces/Repositories/ShoesDataRepository.swift
+++ b/Run Mile/Domain/Interfaces/Repositories/ShoesDataRepository.swift
@@ -13,9 +13,10 @@ protocol ShoesDataRepository: Sendable {
     func fetchHOFShoes() async throws -> [Shoes]
     func fetchCurrentShoes() async throws -> [Shoes]
     func fetchSingleShoes(id: UUID) async throws -> Shoes
-    
+
     func createShoes(shoes: Shoes) async throws
     func updateShoes(shoes: Shoes) async throws
+    func registerWorkouts(shoes: Shoes, workouts: [Workout], shouldMoveRegisteredWorkouts: Bool) async throws
     func deleteShoes(shoes: Shoes) async throws
     func updateSelectedShoes(shoes: Shoes) async
 }

--- a/Run Mile/Domain/UseCases/ChooseShoesUseCase.swift
+++ b/Run Mile/Domain/UseCases/ChooseShoesUseCase.swift
@@ -10,90 +10,76 @@ import Foundation
 
 protocol ChooseShoesUseCase: Sendable {
     func fetchShoesList() async throws -> [Shoes]
-    func registerWorkouts(shoes: Shoes, workouts: [Workout]) async throws
+    func registeredWorkoutConflictCount(targetShoes: Shoes, workouts: [Workout]) async throws -> Int
+    func registerWorkouts(shoes: Shoes, workouts: [Workout], shouldMoveRegisteredWorkouts: Bool) async throws
 }
 
 
 
 final class DefaultChooseShoesUseCase: ChooseShoesUseCase {
     private let repository: ShoesDataRepository
-    
+
     init(repository: ShoesDataRepository) {
         self.repository = repository
     }
-    
+
     public func fetchShoesList() async throws -> [Shoes] {
         try await repository.fetchCurrentShoes()
     }
-    
-    public func registerWorkouts(shoes: Shoes, workouts: [Workout]) async throws {
-        let currentWorkouts = shoes.workouts
-        
-        var newWorkouts = shoes.workouts
-        
-        var isDuplicated = false
-        
-        for currentWorkout in currentWorkouts {
-            if workouts.contains(where: { $0.id == currentWorkout.id }) {
-                isDuplicated = true
-                break
-            }
-        }
-        
-        if isDuplicated {
-            if workouts.count == 1 {
-                await NavigationCoordinator.shared.push(
-                    .init(
-                        title: "중복된 운동 데이터입니다.",
-                        message: "다시 시도해주세요!",
-                        firstButton: .cancel(title: "확인", action: {}),
-                        secondButton: nil
-                    )
-                )
-            } else {
-                workouts.forEach { workout in
-                    if !currentWorkouts.contains(where: { $0.id == workout.id }) {
-                        newWorkouts.append(workout)
-                    }
-                }
-                
-                let newShoes = Shoes(
-                    id: shoes.id,
-                    image: shoes.image,
-                    shoesName: shoes.shoesName,
-                    nickname: shoes.nickname,
-                    goalMileage: shoes.goalMileage,
-                    currentMileage: shoes.currentMileage,
-                    workouts: newWorkouts
-                )
-                
-                try await repository.updateShoes(shoes: newShoes)
-                
-                await NavigationCoordinator.shared.push(
-                    .init(
-                        title: "중복된 운동 데이터가 포함되어 있습니다.",
-                        message: "해당 데이터를 제외한 나머지 운동 데이터만 저장 완료 했습니다.",
-                        firstButton: .cancel(title: "확인", action: {}),
-                        secondButton: nil
-                    )
-                )
-            }
-        } else {
-            newWorkouts.append(contentsOf: workouts)
-            
-            let newShoes = Shoes(
-                id: shoes.id,
-                image: shoes.image,
-                shoesName: shoes.shoesName,
-                nickname: shoes.nickname,
-                goalMileage: shoes.goalMileage,
-                currentMileage: shoes.currentMileage,
-                workouts: newWorkouts
-            )
-            
-            try await repository.updateShoes(shoes: newShoes)
-        }
+
+    /// 선택한 운동 중 다른 신발에 이미 등록된 운동 개수를 반환합니다.
+    public func registeredWorkoutConflictCount(targetShoes: Shoes, workouts: [Workout]) async throws -> Int {
+        let allShoes = try await repository.fetchAllShoes()
+        let workoutIDs = Set(workouts.map(\.id))
+        let conflictIDs = Self.registeredWorkoutConflictIDs(
+            targetShoesID: targetShoes.id,
+            workoutIDs: workoutIDs,
+            shoes: allShoes
+        )
+
+        return conflictIDs.count
     }
-    
-    
+
+    /// 운동을 선택 신발에 등록하고, 필요하면 다른 신발에 등록된 운동을 선택 신발로 이동합니다.
+    public func registerWorkouts(
+        shoes: Shoes,
+        workouts: [Workout],
+        shouldMoveRegisteredWorkouts: Bool
+    ) async throws {
+        let allShoes = try await repository.fetchAllShoes()
+        let targetShoes = allShoes.first(where: { $0.id == shoes.id }) ?? shoes
+        let workoutIDs = Set(workouts.map(\.id))
+        let conflictIDs = Self.registeredWorkoutConflictIDs(
+            targetShoesID: shoes.id,
+            workoutIDs: workoutIDs,
+            shoes: allShoes
+        )
+
+        let registerableWorkoutIDs = shouldMoveRegisteredWorkouts ? workoutIDs : workoutIDs.subtracting(conflictIDs)
+        let registerableWorkouts = workouts.filter { registerableWorkoutIDs.contains($0.id) }
+        guard !registerableWorkouts.isEmpty else {
+            return
+        }
+
+        try await repository.registerWorkouts(
+            shoes: targetShoes,
+            workouts: registerableWorkouts,
+            shouldMoveRegisteredWorkouts: shouldMoveRegisteredWorkouts
+        )
+    }
+
+    private static func registeredWorkoutConflictIDs(
+        targetShoesID: UUID,
+        workoutIDs: Set<UUID>,
+        shoes: [Shoes]
+    ) -> Set<UUID> {
+        var conflictIDs = Set<UUID>()
+
+        for shoe in shoes where shoe.id != targetShoesID {
+            let registeredWorkoutIDs = Set(shoe.workouts.map(\.id))
+            conflictIDs.formUnion(workoutIDs.intersection(registeredWorkoutIDs))
+        }
+
+        return conflictIDs
+    }
 }

--- a/Run Mile/Domain/UseCases/HOFUseCase.swift
+++ b/Run Mile/Domain/UseCases/HOFUseCase.swift
@@ -32,7 +32,7 @@ final class DefaultHOFUseCase: HOFUseCase {
     }
     
     func fetchShoes() async throws -> [Shoes] {
-        try await repository.fetchHOFShoes()
+        try await repository.fetchHOFShoes().sorted(by: compareGraduatedShoes)
     }
     
     func fetchAllRunningWorkouts() async throws -> [Workout] {
@@ -66,6 +66,26 @@ final class DefaultHOFUseCase: HOFUseCase {
 
 
 private extension DefaultHOFUseCase {
+    /// 최근 졸업한 신발이 먼저 보이도록 정렬하고, 기존 데이터처럼 졸업일이 없으면 마지막 운동일과 마일리지로 보정합니다.
+    func compareGraduatedShoes(_ lhs: Shoes, _ rhs: Shoes) -> Bool {
+        let lhsDate = graduationSortDate(for: lhs)
+        let rhsDate = graduationSortDate(for: rhs)
+
+        if lhsDate != rhsDate {
+            return lhsDate > rhsDate
+        }
+
+        if lhs.totalMileage != rhs.totalMileage {
+            return lhs.totalMileage > rhs.totalMileage
+        }
+
+        return lhs.nickname.localizedStandardCompare(rhs.nickname) == .orderedAscending
+    }
+
+    func graduationSortDate(for shoes: Shoes) -> Date {
+        shoes.graduatedAt ?? shoes.workouts.map(\.date).max() ?? .distantPast
+    }
+
     struct DistanceRecordSegment {
         let startDistance: Double
         let endDistance: Double

--- a/Run Mile/Presentation/1.Shoes/1-1.AddShoes/AddShoesView.swift
+++ b/Run Mile/Presentation/1.Shoes/1-1.AddShoes/AddShoesView.swift
@@ -332,9 +332,11 @@ private struct AddShoesTextField: View {
     }
 }
 
+#if DEBUG
 #Preview {
     AddShoesView(
         viewModel: PreviewDIContainer().makeAddShoesViewModel(),
         dismissAction: {}
     )
 }
+#endif

--- a/Run Mile/Presentation/1.Shoes/1-2.ShoesDetail/ShoesDetailView.swift
+++ b/Run Mile/Presentation/1.Shoes/1-2.ShoesDetail/ShoesDetailView.swift
@@ -102,6 +102,7 @@ struct ShoesDetailView: View {
 }
 
 
+#if DEBUG
 #Preview {
     NavigationStack {
         ShoesDetailView(
@@ -111,3 +112,4 @@ struct ShoesDetailView: View {
         )
     }
 }
+#endif

--- a/Run Mile/Presentation/1.Shoes/1-2.ShoesDetail/ShoesDetailViewModel.swift
+++ b/Run Mile/Presentation/1.Shoes/1-2.ShoesDetail/ShoesDetailViewModel.swift
@@ -142,7 +142,8 @@ extension ShoesDetailViewModel {
             goalMileage: goalMileage,
             currentMileage: shoes.currentMileage,
             workouts: shoes.workouts,
-            isGraduate: shoes.isGradutate
+            isGraduate: shoes.isGradutate,
+            graduatedAt: shoes.graduatedAt
         )
         
         Task {
@@ -241,7 +242,8 @@ extension ShoesDetailViewModel {
             goalMileage: shoes.goalMileage,
             currentMileage: shoes.currentMileage,
             workouts: remainingWorkouts,
-            isGraduate: shoes.isGradutate
+            isGraduate: shoes.isGradutate,
+            graduatedAt: shoes.graduatedAt
         )
     }
     
@@ -299,7 +301,8 @@ extension ShoesDetailViewModel {
             goalMileage: shoes.goalMileage,
             currentMileage: shoes.currentMileage,
             workouts: shoes.workouts,
-            isGraduate: true
+            isGraduate: true,
+            graduatedAt: shoes.graduatedAt ?? .now
         )
         
         Task {

--- a/Run Mile/Presentation/1.Shoes/ShoesListView.swift
+++ b/Run Mile/Presentation/1.Shoes/ShoesListView.swift
@@ -100,6 +100,8 @@ struct ShoesListView: View {
     }
 }
 
+#if DEBUG
 #Preview {
     ShoesListView(viewModel: PreviewDIContainer().makeShoesListViewModel())
 }
+#endif

--- a/Run Mile/Presentation/2.Workout/2-1.ChooseShoes/ChooseShoesView.swift
+++ b/Run Mile/Presentation/2.Workout/2-1.ChooseShoes/ChooseShoesView.swift
@@ -11,14 +11,8 @@ import SwiftUI
 struct ChooseShoesView: View {
     @State private var viewModel: ChooseShoesViewModel
     
-    let dismiss: () -> Void
-    
-    init(
-        viewModel: ChooseShoesViewModel,
-        dismiss: @escaping () -> Void
-    ) {
+    init(viewModel: ChooseShoesViewModel) {
         self.viewModel = viewModel
-        self.dismiss = dismiss
     }
     
     var body: some View {
@@ -86,7 +80,7 @@ struct ChooseShoesView: View {
             await viewModel.onAppear()
         }
         .onDisappear {
-            dismiss()
+            viewModel.sheetDidDisappear()
         }
     }
     
@@ -106,14 +100,15 @@ struct ChooseShoesView: View {
     }
 }
 
+#if DEBUG
 #Preview {
     ChooseShoesView(
         viewModel: PreviewDIContainer().makeChooseShoesViewModel(
             workouts: Array(PreviewShoesMockData.workouts.prefix(2))
-        ),
-        dismiss: {}
+        )
     )
 }
+#endif
 
 
 private struct ChooseShoesCell: View {

--- a/Run Mile/Presentation/2.Workout/2-1.ChooseShoes/ChooseShoesViewModel.swift
+++ b/Run Mile/Presentation/2.Workout/2-1.ChooseShoes/ChooseShoesViewModel.swift
@@ -11,18 +11,23 @@ import Foundation
 final class ChooseShoesViewModel {
     private let useCase: ChooseShoesUseCase
     private let workouts: [Workout]
-    
+    private let dismissAction: () -> Void
+    private var isPresentingMoveRegisteredWorkoutsAlert = false
+    private var didHandleSheetDismiss = false
+
     public var shoes: [Shoes] = []
     public var selectedShoe: Shoes? = nil
-    
+
     public var workoutCount: Int { workouts.count }
-    
+
     init(
         useCase: ChooseShoesUseCase,
-        workouts: [Workout]
+        workouts: [Workout],
+        dismissAction: @escaping () -> Void = {}
     ) {
         self.useCase = useCase
         self.workouts = workouts
+        self.dismissAction = dismissAction
     }
 }
 
@@ -41,12 +46,21 @@ extension ChooseShoesViewModel {
             ))
         }
     }
-    
+
     @MainActor
     public func cancelButtonTapped() {
         NavigationCoordinator.shared.dismissSheet()
+        handleSheetDismiss()
     }
-    
+
+    @MainActor
+    public func sheetDidDisappear() {
+        guard !isPresentingMoveRegisteredWorkoutsAlert else {
+            return
+        }
+        handleSheetDismiss()
+    }
+
     @MainActor
     public func shoesCellTapped(shoe: Shoes) {
         if self.selectedShoe?.id == shoe.id {
@@ -55,23 +69,101 @@ extension ChooseShoesViewModel {
             self.selectedShoe = shoe
         }
     }
-    
+
     @MainActor
     public func saveButtonTapped() {
-        guard let selectedShoe = self.selectedShoe else { return }
-        
+        guard let selectedShoe = self.selectedShoe else {
+            return
+        }
+
         Task {
             do {
-                try await useCase.registerWorkouts(shoes: selectedShoe, workouts: workouts)
-                cancelButtonTapped()
+                let conflictCount = try await useCase.registeredWorkoutConflictCount(
+                    targetShoes: selectedShoe,
+                    workouts: workouts
+                )
+
+                if conflictCount > 0 {
+                    presentMoveRegisteredWorkoutsAlert(
+                        selectedShoe: selectedShoe,
+                        conflictCount: conflictCount
+                    )
+                } else {
+                    try await registerWorkouts(
+                        to: selectedShoe,
+                        shouldMoveRegisteredWorkouts: false
+                    )
+                }
             } catch {
-                NavigationCoordinator.shared.push(.init(
-                    title: "저장 과정 중 오류가 발생했습니다.",
-                    message: "같은 오류가 계속 발생할 시 문의 부탁드립니다.\n** \(error.localizedDescription)",
-                    firstButton: .cancel(title: "확인", action: {}),
-                    secondButton: nil
-                ))
+                presentSaveFailureAlert(error: error)
             }
         }
+    }
+
+    @MainActor
+    private func presentMoveRegisteredWorkoutsAlert(selectedShoe: Shoes, conflictCount: Int) {
+        isPresentingMoveRegisteredWorkoutsAlert = true
+        NavigationCoordinator.shared.push(.init(
+            title: "이미 등록된 운동이 포함되어 있습니다.",
+            message: "선택한 운동 중 \(conflictCount)개가 이미 다른 신발에 등록되어 있습니다.\n해당 운동을 \(selectedShoe.nickname)로 옮길까요?",
+            firstButton: .cancel(title: "취소", action: { [self] in
+                Task {
+                    await MainActor.run {
+                        self.isPresentingMoveRegisteredWorkoutsAlert = false
+                    }
+                }
+            }),
+            secondButton: .ok(title: "옮기기", action: { [self] in
+                Task {
+                    await self.moveRegisteredWorkouts(to: selectedShoe)
+                }
+            })
+        ))
+    }
+
+    @MainActor
+    private func moveRegisteredWorkouts(to selectedShoe: Shoes) async {
+        isPresentingMoveRegisteredWorkoutsAlert = false
+        do {
+            try await registerWorkouts(
+                to: selectedShoe,
+                shouldMoveRegisteredWorkouts: true
+            )
+        } catch {
+            presentSaveFailureAlert(error: error)
+        }
+    }
+
+    @MainActor
+    private func registerWorkouts(
+        to selectedShoe: Shoes,
+        shouldMoveRegisteredWorkouts: Bool
+    ) async throws {
+        try await useCase.registerWorkouts(
+            shoes: selectedShoe,
+            workouts: workouts,
+            shouldMoveRegisteredWorkouts: shouldMoveRegisteredWorkouts
+        )
+        cancelButtonTapped()
+    }
+
+    @MainActor
+    private func presentSaveFailureAlert(error: Error) {
+        NavigationCoordinator.shared.push(.init(
+            title: "저장 과정 중 오류가 발생했습니다.",
+            message: "같은 오류가 계속 발생할 시 문의 부탁드립니다.\n** \(error.localizedDescription)",
+            firstButton: .cancel(title: "확인", action: {}),
+            secondButton: nil
+        ))
+    }
+
+    @MainActor
+    private func handleSheetDismiss() {
+        guard !didHandleSheetDismiss else {
+            return
+        }
+
+        didHandleSheetDismiss = true
+        dismissAction()
     }
 }

--- a/Run Mile/Presentation/2.Workout/2-2.AutoMileage/AutoMileageShoesView.swift
+++ b/Run Mile/Presentation/2.Workout/2-2.AutoMileage/AutoMileageShoesView.swift
@@ -99,11 +99,13 @@ struct AutoMileageShoesView: View {
     }
 }
 
+#if DEBUG
 #Preview {
     AutoMileageShoesView(
         viewModel: PreviewDIContainer().makeAutoMileageShoesViewModel()
     )
 }
+#endif
 
 
 private struct ChooseShoesCell: View {

--- a/Run Mile/Presentation/2.Workout/2-3.WorkoutDetail/Charts/CustomChartView.swift
+++ b/Run Mile/Presentation/2.Workout/2-3.WorkoutDetail/Charts/CustomChartView.swift
@@ -11,18 +11,22 @@ import Charts
 
 struct CustomChartView: View {
     let category: ChartList
-    
+
     let samples: [ChartSample]
     let xScale: ClosedRange<Int>
     let yScale: ClosedRange<Double>
-    
+
+    private var safeYScale: ClosedRange<Double> {
+        ChartAxisValueFactory.safeYScale(for: yScale)
+    }
+
     var body: some View {
         VStack(alignment: .leading) {
             Label(category.labelTitle, systemImage: category.symbolTitle)
                 .foregroundStyle(category.color)
                 .font(.headline)
                 .padding(.horizontal)
-            
+
             Chart {
                 ForEach(samples) { point in
                     LineMark(
@@ -34,7 +38,7 @@ struct CustomChartView: View {
                     .interpolationMethod(.catmullRom)
                 }
             }
-            .chartYScale(domain: yScale)
+            .chartYScale(domain: safeYScale)
             .frame(height: 200)
             .padding()
             .runMileBrutalCard()
@@ -49,35 +53,23 @@ struct CustomChartView: View {
                     }
             }
             .chartXAxis {
-                let from = self.xScale.lowerBound
-                let through = self.xScale.upperBound
-                let stride = Array(stride(
-                    from: from,
-                    through: through,
-                    by: (through - from) / 4
-                ))
-                
-                AxisMarks(values: stride) { axis in
+                let xAxisValues = ChartAxisValueFactory.xAxisValues(for: xScale)
+
+                AxisMarks(values: xAxisValues) { axis in
                     AxisGridLine()
-                    let value = stride[axis.index]
+                    let value = xAxisValues[axis.index]
                     let duration = Duration.seconds(value)
                     let formattedString = duration.formatted(.time(pattern: .hourMinuteSecond))
                     AxisValueLabel(formattedString, centered: false)
                 }
             }
             .chartYAxis {
-                let from = self.yScale.lowerBound
-                let through = self.yScale.upperBound
-                let stride = Array(stride(
-                    from: from,
-                    through: through,
-                    by: (through - from) / 4
-                ))
-                
-                AxisMarks(position: .trailing, values: stride) { axis in
+                let yAxisValues = ChartAxisValueFactory.yAxisValues(for: safeYScale)
+
+                AxisMarks(position: .trailing, values: yAxisValues) { axis in
                     AxisGridLine()
-                    let value = stride[axis.index]
-                    
+                    let value = yAxisValues[axis.index]
+
                     switch self.category {
                     case .heart, .power, .groundContactTime:
                         AxisValueLabel(String(format: "%.0f", value), centered: false)
@@ -88,6 +80,45 @@ struct CustomChartView: View {
                     }
                 }
             }
+        }
+    }
+}
+
+
+enum ChartAxisValueFactory {
+    /// x축 범위에 맞춰 중복 없는 시간 라벨 값을 생성합니다.
+    static func xAxisValues(for scale: ClosedRange<Int>) -> [Int] {
+        guard scale.lowerBound < scale.upperBound else {
+            return [scale.lowerBound]
+        }
+
+        let step = max((scale.upperBound - scale.lowerBound) / 4, 1)
+        var values = Array(stride(from: scale.lowerBound, through: scale.upperBound, by: step))
+
+        if values.last != scale.upperBound {
+            values.append(scale.upperBound)
+        }
+
+        return values
+    }
+
+    /// 동일한 min/max 값이 들어와도 Charts가 그릴 수 있도록 y축 범위를 보정합니다.
+    static func safeYScale(for scale: ClosedRange<Double>) -> ClosedRange<Double> {
+        guard scale.lowerBound < scale.upperBound else {
+            let padding = max(abs(scale.lowerBound) * 0.1, 1)
+            return (scale.lowerBound - padding)...(scale.upperBound + padding)
+        }
+
+        return scale
+    }
+
+    /// y축 범위에 맞춰 최소/최대 포함 5개 라벨 값을 생성합니다.
+    static func yAxisValues(for scale: ClosedRange<Double>) -> [Double] {
+        let safeScale = safeYScale(for: scale)
+        let step = (safeScale.upperBound - safeScale.lowerBound) / 4
+
+        return (0...4).map { index in
+            safeScale.lowerBound + (step * Double(index))
         }
     }
 }

--- a/Run Mile/Presentation/2.Workout/2-3.WorkoutDetail/WorkoutDetailView.swift
+++ b/Run Mile/Presentation/2.Workout/2-3.WorkoutDetail/WorkoutDetailView.swift
@@ -57,6 +57,7 @@ struct WorkoutDetailView: View {
     }
 }
 
+#if DEBUG
 #Preview {
     NavigationStack {
         WorkoutDetailView(
@@ -66,3 +67,4 @@ struct WorkoutDetailView: View {
         )
     }
 }
+#endif

--- a/Run Mile/Presentation/2.Workout/WorkoutListView.swift
+++ b/Run Mile/Presentation/2.Workout/WorkoutListView.swift
@@ -220,8 +220,10 @@ struct WorkoutListView: View {
     }
 }
 
+#if DEBUG
 #Preview {
     NavigationStack {
         WorkoutListView(viewModel: PreviewDIContainer().makeWorkoutListViewModel())
     }
 }
+#endif

--- a/Run Mile/Presentation/3.MyPage/3-1.HallOfFame/HOFReportView.swift
+++ b/Run Mile/Presentation/3.MyPage/3-1.HallOfFame/HOFReportView.swift
@@ -248,6 +248,7 @@ struct HOFReportView: View {
 }
 
 
+#if DEBUG
 #Preview("HOF Report") {
     NavigationStack {
         HOFReportView(
@@ -257,3 +258,4 @@ struct HOFReportView: View {
         )
     }
 }
+#endif

--- a/Run Mile/Presentation/3.MyPage/3-1.HallOfFame/HOFView.swift
+++ b/Run Mile/Presentation/3.MyPage/3-1.HallOfFame/HOFView.swift
@@ -209,8 +209,10 @@ struct HOFShoesCard: View {
 }
 
 
+#if DEBUG
 #Preview("Hall of Fame") {
     NavigationStack {
         HOFView(viewModel: PreviewDIContainer().makeHOFViewModel())
     }
 }
+#endif

--- a/Run Mile/Presentation/3.MyPage/3-4.Information/InformationView.swift
+++ b/Run Mile/Presentation/3.MyPage/3-4.Information/InformationView.swift
@@ -212,8 +212,10 @@ private enum BrandIcon {
     case linkedIn
 }
 
+#if DEBUG
 #Preview {
     NavigationStack {
         InformationView(viewModel: PreviewDIContainer().makeInformationViewModel())
     }
 }
+#endif

--- a/Run Mile/Presentation/3.MyPage/MyPageView.swift
+++ b/Run Mile/Presentation/3.MyPage/MyPageView.swift
@@ -173,6 +173,8 @@ private struct ScaleButtonStyle: ButtonStyle {
 }
 
 
+#if DEBUG
 #Preview {
     MyPageView(viewModel: PreviewDIContainer().makeMyPageViewModel())
 }
+#endif

--- a/Run Mile/Resources/PrivacyInfo.xcprivacy
+++ b/Run Mile/Resources/PrivacyInfo.xcprivacy
@@ -1,0 +1,23 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>NSPrivacyAccessedAPITypes</key>
+	<array>
+		<dict>
+			<key>NSPrivacyAccessedAPIType</key>
+			<string>NSPrivacyAccessedAPICategoryUserDefaults</string>
+			<key>NSPrivacyAccessedAPITypeReasons</key>
+			<array>
+				<string>CA92.1</string>
+			</array>
+		</dict>
+	</array>
+	<key>NSPrivacyCollectedDataTypes</key>
+	<array/>
+	<key>NSPrivacyTracking</key>
+	<false/>
+	<key>NSPrivacyTrackingDomains</key>
+	<array/>
+</dict>
+</plist>

--- a/Run MileTests/ChartAxisValueFactoryTests.swift
+++ b/Run MileTests/ChartAxisValueFactoryTests.swift
@@ -1,0 +1,33 @@
+//
+//  ChartAxisValueFactoryTests.swift
+//  Run MileTests
+//
+//  Created by Codex on 6/14/26.
+//
+
+import Testing
+@testable import Run_Mile
+
+
+struct ChartAxisValueFactoryTests {
+    @Test func sameXScaleReturnsSingleTick() {
+        let values = ChartAxisValueFactory.xAxisValues(for: 120...120)
+        
+        #expect(values == [120])
+    }
+    
+    @Test func shortXScaleDoesNotCreateDuplicateTicks() {
+        let values = ChartAxisValueFactory.xAxisValues(for: 0...3)
+        
+        #expect(values == [0, 1, 2, 3])
+    }
+    
+    @Test func sameYScaleReturnsPaddedDomainAndTicks() {
+        let scale = ChartAxisValueFactory.safeYScale(for: 100...100)
+        let values = ChartAxisValueFactory.yAxisValues(for: 100...100)
+        
+        #expect(scale.lowerBound < 100)
+        #expect(scale.upperBound > 100)
+        #expect(values.count == 5)
+    }
+}

--- a/Run MileTests/ChooseShoesUseCaseTests.swift
+++ b/Run MileTests/ChooseShoesUseCaseTests.swift
@@ -1,0 +1,216 @@
+//
+//  ChooseShoesUseCaseTests.swift
+//  Run MileTests
+//
+//  Created by Codex on 6/14/26.
+//
+
+import Foundation
+import HealthKit
+import Testing
+@testable import Run_Mile
+
+
+struct ChooseShoesUseCaseTests {
+    @Test func conflictCountIncludesWorkoutsRegisteredToOtherShoes() async throws {
+        let workout = makeWorkout()
+        let firstShoes = makeShoes(nickname: "이전 신발", workouts: [workout])
+        let targetShoes = makeShoes(nickname: "새 신발")
+        let repository = FakeChooseShoesRepository(shoes: [firstShoes, targetShoes])
+        let useCase = DefaultChooseShoesUseCase(repository: repository)
+
+        let conflictCount = try await useCase.registeredWorkoutConflictCount(
+            targetShoes: targetShoes,
+            workouts: [workout]
+        )
+
+        #expect(conflictCount == 1)
+    }
+
+    @Test func registerWorkoutsMovesRegisteredWorkoutToTargetShoes() async throws {
+        let workout = makeWorkout()
+        let firstShoes = makeShoes(nickname: "이전 신발", workouts: [workout])
+        let targetShoes = makeShoes(nickname: "새 신발")
+        let repository = FakeChooseShoesRepository(shoes: [firstShoes, targetShoes])
+        let useCase = DefaultChooseShoesUseCase(repository: repository)
+
+        try await useCase.registerWorkouts(
+            shoes: targetShoes,
+            workouts: [workout],
+            shouldMoveRegisteredWorkouts: true
+        )
+
+        let shoes = try await repository.fetchAllShoes()
+        let updatedFirstShoes = try #require(shoes.first(where: { $0.id == firstShoes.id }))
+        let updatedTargetShoes = try #require(shoes.first(where: { $0.id == targetShoes.id }))
+
+        #expect(updatedFirstShoes.workouts.isEmpty)
+        #expect(updatedTargetShoes.workouts.map(\.id) == [workout.id])
+    }
+
+    @Test func registerWorkoutsDoesNotDuplicateExistingTargetWorkout() async throws {
+        let workout = makeWorkout()
+        let targetShoes = makeShoes(nickname: "현재 신발", workouts: [workout])
+        let repository = FakeChooseShoesRepository(shoes: [targetShoes])
+        let useCase = DefaultChooseShoesUseCase(repository: repository)
+
+        try await useCase.registerWorkouts(
+            shoes: targetShoes,
+            workouts: [workout],
+            shouldMoveRegisteredWorkouts: false
+        )
+
+        let shoes = try await repository.fetchAllShoes()
+        let updatedTargetShoes = try #require(shoes.first(where: { $0.id == targetShoes.id }))
+
+        #expect(updatedTargetShoes.workouts.map(\.id) == [workout.id])
+    }
+
+    @Test func registerWorkoutsWithoutMoveDoesNotDuplicateOtherShoesWorkout() async throws {
+        let workout = makeWorkout()
+        let firstShoes = makeShoes(nickname: "이전 신발", workouts: [workout])
+        let targetShoes = makeShoes(nickname: "새 신발")
+        let repository = FakeChooseShoesRepository(shoes: [firstShoes, targetShoes])
+        let useCase = DefaultChooseShoesUseCase(repository: repository)
+
+        try await useCase.registerWorkouts(
+            shoes: targetShoes,
+            workouts: [workout],
+            shouldMoveRegisteredWorkouts: false
+        )
+
+        let shoes = try await repository.fetchAllShoes()
+        let updatedFirstShoes = try #require(shoes.first(where: { $0.id == firstShoes.id }))
+        let updatedTargetShoes = try #require(shoes.first(where: { $0.id == targetShoes.id }))
+
+        #expect(updatedFirstShoes.workouts.map(\.id) == [workout.id])
+        #expect(updatedTargetShoes.workouts.isEmpty)
+    }
+}
+
+
+private actor FakeChooseShoesRepository: ShoesDataRepository {
+    private var shoes: [Shoes]
+
+    init(shoes: [Shoes]) {
+        self.shoes = shoes
+    }
+
+    func fetchAllShoes() async throws -> [Shoes] {
+        shoes
+    }
+
+    func fetchHOFShoes() async throws -> [Shoes] {
+        shoes.filter(\.isGradutate)
+    }
+
+    func fetchCurrentShoes() async throws -> [Shoes] {
+        shoes.filter { !$0.isGradutate }
+    }
+
+    func fetchSingleShoes(id: UUID) async throws -> Shoes {
+        guard let shoe = shoes.first(where: { $0.id == id }) else {
+            throw FakeChooseShoesRepositoryError.shoesNotFound
+        }
+        return shoe
+    }
+
+    func createShoes(shoes: Shoes) async throws {
+        self.shoes.append(shoes)
+    }
+
+    func updateShoes(shoes: Shoes) async throws {
+        guard let index = self.shoes.firstIndex(where: { $0.id == shoes.id }) else {
+            throw FakeChooseShoesRepositoryError.shoesNotFound
+        }
+        self.shoes[index] = shoes
+    }
+
+    func registerWorkouts(
+        shoes: Shoes,
+        workouts: [Workout],
+        shouldMoveRegisteredWorkouts: Bool
+    ) async throws {
+        guard let targetIndex = self.shoes.firstIndex(where: { $0.id == shoes.id }) else {
+            throw FakeChooseShoesRepositoryError.shoesNotFound
+        }
+
+        let workoutIDs = Set(workouts.map(\.id))
+
+        if shouldMoveRegisteredWorkouts {
+            for index in self.shoes.indices where self.shoes[index].id != shoes.id {
+                let remainingWorkouts = self.shoes[index].workouts.filter { !workoutIDs.contains($0.id) }
+                self.shoes[index] = self.shoes[index].replacingWorkouts(remainingWorkouts)
+            }
+        }
+
+        let existingWorkoutIDs = Set(self.shoes[targetIndex].workouts.map(\.id))
+        let newWorkouts = workouts.filter { !existingWorkoutIDs.contains($0.id) }
+        self.shoes[targetIndex] = self.shoes[targetIndex].replacingWorkouts(
+            self.shoes[targetIndex].workouts + newWorkouts
+        )
+    }
+
+    func deleteShoes(shoes: Shoes) async throws {
+        self.shoes.removeAll { $0.id == shoes.id }
+    }
+
+    func updateSelectedShoes(shoes: Shoes) async {}
+}
+
+
+private enum FakeChooseShoesRepositoryError: Error {
+    case shoesNotFound
+}
+
+
+private extension Shoes {
+    func replacingWorkouts(_ workouts: [Workout]) -> Shoes {
+        Shoes(
+            id: id,
+            image: image,
+            shoesName: shoesName,
+            nickname: nickname,
+            goalMileage: goalMileage,
+            currentMileage: currentMileage,
+            workouts: workouts,
+            isGraduate: isGradutate
+        )
+    }
+}
+
+
+private func makeShoes(
+    nickname: String,
+    workouts: [Workout] = []
+) -> Shoes {
+    Shoes(
+        id: UUID(),
+        image: Data(),
+        shoesName: "Adidas 아디스타 4",
+        nickname: nickname,
+        goalMileage: 800,
+        currentMileage: 0,
+        workouts: workouts
+    )
+}
+
+
+private func makeWorkout(
+    distance: Double = 5000,
+    duration: TimeInterval = 1800
+) -> Workout {
+    let startDate = Date(timeIntervalSince1970: 0)
+    let endDate = startDate.addingTimeInterval(duration)
+    let healthWorkout = HKWorkout(
+        activityType: .running,
+        start: startDate,
+        end: endDate,
+        duration: duration,
+        totalEnergyBurned: HKQuantity(unit: .kilocalorie(), doubleValue: 300),
+        totalDistance: HKQuantity(unit: .meter(), doubleValue: distance),
+        metadata: nil
+    )
+
+    return Workout(workout: healthWorkout)
+}

--- a/Run MileTests/HealthBackgroundSyncServiceTests.swift
+++ b/Run MileTests/HealthBackgroundSyncServiceTests.swift
@@ -1,0 +1,24 @@
+//
+//  HealthBackgroundSyncServiceTests.swift
+//  Run MileTests
+//
+//  Created by Codex on 6/14/26.
+//
+
+import Testing
+@testable import Run_Mile
+
+
+struct HealthBackgroundSyncServiceTests {
+    @Test func remainingPendingWorkoutIDsRemovesProcessedAndInvalidIDs() {
+        let currentIDs = ["valid-1", "deleted", "valid-2", "malformed"]
+        let removingIDs: Set<String> = ["deleted", "malformed"]
+        
+        let result = DefaultHealthBackgroundSyncService.remainingPendingRunningWorkoutIDs(
+            currentIDs: currentIDs,
+            removingIDs: removingIDs
+        )
+        
+        #expect(result == ["valid-1", "valid-2"])
+    }
+}

--- a/Run MileTests/ShoeCatalogTests.swift
+++ b/Run MileTests/ShoeCatalogTests.swift
@@ -1,0 +1,36 @@
+//
+//  ShoeCatalogTests.swift
+//  Run MileTests
+//
+//  Created by Codex on 6/14/26.
+//
+
+import Testing
+@testable import Run_Mile
+
+
+struct ShoeCatalogTests {
+    @Test func defaultBrandStartsWithAdidas() {
+        #expect(ShoeCatalog.defaultBrand == "Adidas")
+        #expect(ShoeCatalog.defaultModel == "아디스타 4")
+        #expect(ShoeCatalog.brandList.first == "Adidas")
+    }
+    
+    @Test func knownShoesNameRestoresCatalogSelection() {
+        let selection = ShoeCatalog.selection(for: "Adidas 아디스타 4")
+        
+        #expect(selection.selectedBrand == "Adidas")
+        #expect(selection.selectedModel == "아디스타 4")
+        #expect(selection.customBrand.isEmpty)
+        #expect(selection.customModel.isEmpty)
+    }
+    
+    @Test func removedCatalogModelRestoresAsCustomModel() {
+        let selection = ShoeCatalog.selection(for: "Nike 오래된 모델")
+        
+        #expect(selection.selectedBrand == "Nike")
+        #expect(selection.selectedModel == ShoeCatalog.other)
+        #expect(selection.customBrand.isEmpty)
+        #expect(selection.customModel == "오래된 모델")
+    }
+}


### PR DESCRIPTION
close #81

## Summary
이 PR은 QA 과정에서 확인된 주요 동작 문제를 수정하고, 관련 회귀를 막기 위한 테스트와 PrivacyInfo 리소스를 추가했습니다. 운동을 다른 신발로 다시 등록할 때 기존 연결이 올바르게 변경되도록 개선하고, Hall of Fame의 졸업 시기 및 정렬 기준을 보강했습니다.

## Key Changes

### 1. Shoes & Workout Registration Fixes
- 추가한 운동을 다른 신발로 등록할 경우 기존 등록 신발이 올바르게 변경되도록 수정했습니다.
- `ChooseShoesUseCase`, `ChooseShoesViewModel`, `ShoesDataRepositoryImpl` 흐름을 정리해 신발-운동 연결 변경 시 데이터 정합성을 개선했습니다.
- 신발 상세/리스트/운동 관련 화면에서 변경 후 상태가 반영되도록 갱신 흐름을 보강했습니다.

### 2. HOF Graduation & Sorting Update
- `Shoes` 엔티티에 명예의 전당 졸업 시기 관련 값을 추가했습니다.
- CoreData 모델과 Mapper, Repository 계층을 업데이트해 HOF 졸업 정보를 저장/조회할 수 있도록 했습니다.
- `HOFUseCase`의 정렬 기준을 보강해 명예의 전당 표시 순서를 더 명확하게 정리했습니다.

### 3. Background Sync & UI QA Fixes
- `HealthBackgroundSyncService`와 관련 DI/Preview 구성을 수정했습니다.
- 운동 상세 차트 축 표시 관련 로직을 조정했습니다.
- 여러 SwiftUI 화면에 필요한 상태/변경 감지를 보강해 QA 중 확인된 화면 갱신 문제를 수정했습니다.

### 4. PrivacyInfo & Tests
- `PrivacyInfo.xcprivacy`를 추가했습니다.
- `ChooseShoesUseCaseTests`, `ChartAxisValueFactoryTests`, `HealthBackgroundSyncServiceTests`, `ShoeCatalogTests`를 추가해 주요 수정 사항의 회귀 검증 기반을 마련했습니다.

## Impact
- 운동을 다른 신발로 재등록할 때 데이터가 더 안정적으로 변경됩니다.
- HOF 화면에서 신발 졸업 정보와 정렬 기준이 더 정확하게 반영됩니다.
- QA에서 발견된 핵심 사용 흐름의 불안정성을 줄이고, 관련 테스트 기반이 보강됩니다.

## Validation
- 변경 사항은 커밋 기록과 `origin/develop...HEAD` diff 기준으로 확인했습니다.
- 로컬 빌드/테스트는 별도로 실행하지 않았습니다.