### PR TITLE
[Fix] 출시 전 리젝 가능 사항 수정

### DIFF
--- a/PrivacyPolicy.md
+++ b/PrivacyPolicy.md
@@ -1,70 +1,54 @@
 **Privacy Policy**
 
-This privacy policy applies to the Run Mile app (hereby referred to as "Application") for mobile devices that was created by mooninbeom (hereby referred to as "Service Provider") as a Free service. This service is intended for use "AS IS".
+Run Mile is an app that helps users manage running shoe mileage and review workout analysis based on running workout records stored in Apple Health. This Privacy Policy explains what data Run Mile uses and for what purposes.
 
-**Information Collection and Use**
+**Data Used by Run Mile**
 
-The Application collects information when you download and use it. This information may include information such as
+With the user's permission, Run Mile reads the following data from Apple HealthKit:
 
-*   Your device's Internet Protocol address (e.g. IP address)
-*   The pages of the Application that you visit, the time and date of your visit, the time spent on those pages
-*   The time spent on the Application
-*   The operating system you use on your mobile device
+* Running workout records
+* Workout distance, duration, and pace
+* Workout routes
+* Heart rate, running power, stride length, vertical oscillation, ground contact time, and other running analysis metrics
 
-The Application does not gather precise information about the location of your mobile device.
+This data is used to calculate shoe mileage, display workout history, show workout detail charts, display workout routes on maps, and provide pace and elevation analysis.
 
-The Application collects your device's location, which helps the Service Provider determine your approximate geographical location and make use of in below ways:
+**Health Data and Workout Routes**
 
-*   Geolocation Services: The Service Provider utilizes location data to provide features such as personalized content, relevant recommendations, and location-based services.
-*   Analytics and Improvements: Aggregated and anonymized location data helps the Service Provider to analyze user behavior, identify trends, and improve the overall performance and functionality of the Application.
-*   Third-Party Services: Periodically, the Service Provider may transmit anonymized location data to external services. These services assist them in enhancing the Application and optimizing their offerings.
+Run Mile processes HealthKit running workout records, health data, and workout routes on the user's device. This data is not transmitted to Run Mile's own server and is not used for advertising tracking or third-party marketing purposes.
 
-The Service Provider may use the information you provided to contact you from time to time to provide you with important information, required notices and marketing promotions.
+Users can change or revoke Run Mile's HealthKit access at any time in the iOS Settings app or Apple Health app.
 
-For a better experience, while using the Application, the Service Provider may require you to provide us with certain personally identifiable information. The information that the Service Provider request will be retained by them and used as described in this privacy policy.
+**Diagnostic Data**
 
-**Third Party Access**
+Run Mile uses Firebase Crashlytics to improve app stability. If the app crashes or encounters an error, diagnostic information such as crash logs, stack traces, device model, OS version, and app version may be sent to Google Firebase.
 
-Only aggregated, anonymized data is periodically transmitted to external services to aid the Service Provider in improving the Application and their service. The Service Provider may share your information with third parties in the ways that are described in this privacy statement.
+Diagnostic data collected through Crashlytics is used only to analyze app errors and improve stability. It is not used for advertising tracking.
 
-The Service Provider may disclose User Provided and Automatically Collected Information:
+**Notifications**
 
-*   as required by law, such as to comply with a subpoena, or similar legal process;
-*   when they believe in good faith that disclosure is necessary to protect their rights, protect your safety or the safety of others, investigate fraud, or respond to a government request;
-*   with their trusted services providers who work on their behalf, do not have an independent use of the information we disclose to them, and have agreed to adhere to the rules set forth in this privacy statement.
+If the user allows notifications, Run Mile may use local notifications to remind the user to record shoe mileage after a workout, notify the user when automatic mileage registration is complete, or notify the user when a shoe reaches its target mileage. Notification permissions can be changed at any time in the iOS Settings app.
 
-**Opt-Out Rights**
+**Data Retention**
 
-You can stop all collection of information by the Application easily by uninstalling it. You may use the standard uninstall processes as may be available as part of your mobile device or via the mobile application marketplace or network.
+Shoe information, workout-to-shoe registration data, and automatic registration settings are stored on the user's device. If the user deletes the app, the app data stored on the device is also deleted. Original HealthKit workout records are managed by Apple Health and are not deleted when Run Mile is deleted.
 
-**Data Retention Policy**
+**Third-Party Services**
 
-The Service Provider will retain User Provided data for as long as you use the Application and for a reasonable time thereafter. If you'd like them to delete User Provided Data that you have provided via the Application, please contact them at dlsqja567@naver.com and they will respond in a reasonable time.
+Run Mile uses Firebase Crashlytics to improve app stability. Firebase's data handling is governed by Google's Firebase policies.
 
-**Children**
+**Children's Privacy**
 
-The Service Provider does not use the Application to knowingly solicit data from or market to children under the age of 13.
+Run Mile does not knowingly collect personal information from children under the age of 13. If you have any related concerns, please contact us using the email address below.
 
-The Service Provider does not knowingly collect personally identifiable information from children. The Service Provider encourages all children to never submit any personally identifiable information through the Application and/or Services. The Service Provider encourage parents and legal guardians to monitor their children's Internet usage and to help enforce this Policy by instructing their children never to provide personally identifiable information through the Application and/or Services without their permission. If you have reason to believe that a child has provided personally identifiable information to the Service Provider through the Application and/or Services, please contact the Service Provider (dlsqja567@naver.com) so that they will be able to take the necessary actions. You must also be at least 16 years of age to consent to the processing of your personally identifiable information in your country (in some countries we may allow your parent or guardian to do so on your behalf).
+**Changes to This Privacy Policy**
 
-**Security**
-
-The Service Provider is concerned about safeguarding the confidentiality of your information. The Service Provider provides physical, electronic, and procedural safeguards to protect information the Service Provider processes and maintains.
-
-**Changes**
-
-This Privacy Policy may be updated from time to time for any reason. The Service Provider will notify you of any changes to the Privacy Policy by updating this page with the new Privacy Policy. You are advised to consult this Privacy Policy regularly for any changes, as continued use is deemed approval of all changes.
-
-This privacy policy is effective as of 2025-06-11
-
-**Your Consent**
-
-By using the Application, you are consenting to the processing of your information as set forth in this Privacy Policy now and as amended by us.
+This Privacy Policy may be updated from time to time due to changes in app functionality or legal requirements. Any changes will be posted in this document.
 
 **Contact Us**
 
-If you have any questions regarding privacy while using the Application, or have questions about the practices, please contact the Service Provider via email at dlsqja567@naver.com.
+If you have any questions about this Privacy Policy or Run Mile's data practices, please contact us at:
 
-* * *
+dlsqja567@naver.com
 
-This privacy policy page was generated by [App Privacy Policy Generator](https://app-privacy-policy-generator.nisrulz.com/)
+Effective date: June 23, 2026

--- a/Run Mile.xcodeproj/project.pbxproj
+++ b/Run Mile.xcodeproj/project.pbxproj
@@ -498,7 +498,7 @@
 				INFOPLIST_KEY_LSApplicationCategoryType = "public.app-category.healthcare-fitness";
 				INFOPLIST_KEY_NSCameraUsageDescription = "러닝화 사진을 촬영해 신발 프로필 이미지로 등록하기 위해 카메라를 사용합니다.";
 				INFOPLIST_KEY_NSHealthShareUsageDescription = "러닝 운동 기록, 경로, 거리, 시간, 페이스, 심박, 파워, 보폭 등 운동 분석에 필요한 건강 데이터를 불러옵니다.";
-				INFOPLIST_KEY_NSHealthUpdateUsageDescription = "디버그 시뮬레이터에서 테스트 운동 샘플을 생성하기 위해 건강 데이터 쓰기 권한을 사용합니다.";
+				INFOPLIST_KEY_NSHealthUpdateUsageDescription = "앱에서 운동 기록을 가져오기 위해서는 사용자의 허락이 필요합니다!";
 				INFOPLIST_KEY_UIApplicationSceneManifest_Generation = YES;
 				INFOPLIST_KEY_UIApplicationSupportsIndirectInputEvents = YES;
 				INFOPLIST_KEY_UILaunchScreen_Generation = YES;
@@ -542,6 +542,7 @@
 				INFOPLIST_KEY_LSApplicationCategoryType = "public.app-category.healthcare-fitness";
 				INFOPLIST_KEY_NSCameraUsageDescription = "러닝화 사진을 촬영해 신발 프로필 이미지로 등록하기 위해 카메라를 사용합니다.";
 				INFOPLIST_KEY_NSHealthShareUsageDescription = "러닝 운동 기록, 경로, 거리, 시간, 페이스, 심박, 파워, 보폭 등 운동 분석에 필요한 건강 데이터를 불러옵니다.";
+				INFOPLIST_KEY_NSHealthUpdateUsageDescription = "앱에서 운동 기록을 가져오기 위해서는 사용자의 허락이 필요합니다!";
 				INFOPLIST_KEY_UIApplicationSceneManifest_Generation = YES;
 				INFOPLIST_KEY_UIApplicationSupportsIndirectInputEvents = YES;
 				INFOPLIST_KEY_UILaunchScreen_Generation = YES;

--- a/Run Mile.xcodeproj/project.pbxproj
+++ b/Run Mile.xcodeproj/project.pbxproj
@@ -11,12 +11,8 @@
 		2C079FBF2DB2505700B1EE0D /* RealmSwift in Frameworks */ = {isa = PBXBuildFile; productRef = 2C079FBE2DB2505700B1EE0D /* RealmSwift */; };
 		2C079FC02DB2507700B1EE0D /* RealmSwift in Embed Frameworks */ = {isa = PBXBuildFile; productRef = 2C079FBE2DB2505700B1EE0D /* RealmSwift */; settings = {ATTRIBUTES = (CodeSignOnCopy, ); }; };
 		2CE46E212DAE78D7008C6FBC /* .gitignore in Resources */ = {isa = PBXBuildFile; fileRef = 2CE46E202DAE78D7008C6FBC /* .gitignore */; };
-		2CEF99392E925A5700CBA323 /* FirebaseAnalytics in Frameworks */ = {isa = PBXBuildFile; productRef = 2CEF99382E925A5700CBA323 /* FirebaseAnalytics */; };
-		2CEF993B2E925A5700CBA323 /* FirebaseAnalyticsCore in Frameworks */ = {isa = PBXBuildFile; productRef = 2CEF993A2E925A5700CBA323 /* FirebaseAnalyticsCore */; };
-		2CEF993D2E925A5700CBA323 /* FirebaseAnalyticsIdentitySupport in Frameworks */ = {isa = PBXBuildFile; productRef = 2CEF993C2E925A5700CBA323 /* FirebaseAnalyticsIdentitySupport */; };
 		2CEF993F2E925A5700CBA323 /* FirebaseCore in Frameworks */ = {isa = PBXBuildFile; productRef = 2CEF993E2E925A5700CBA323 /* FirebaseCore */; };
 		2CEF99412E925A5700CBA323 /* FirebaseCrashlytics in Frameworks */ = {isa = PBXBuildFile; productRef = 2CEF99402E925A5700CBA323 /* FirebaseCrashlytics */; };
-		2CEF99432E925A5700CBA323 /* FirebaseRemoteConfig in Frameworks */ = {isa = PBXBuildFile; productRef = 2CEF99422E925A5700CBA323 /* FirebaseRemoteConfig */; };
 		2CEF99482E925CB400CBA323 /* GoogleService-Info.plist in Resources */ = {isa = PBXBuildFile; fileRef = 2CEF99472E925CB400CBA323 /* GoogleService-Info.plist */; };
 /* End PBXBuildFile section */
 
@@ -97,12 +93,8 @@
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				2CEF993D2E925A5700CBA323 /* FirebaseAnalyticsIdentitySupport in Frameworks */,
 				2CEF993F2E925A5700CBA323 /* FirebaseCore in Frameworks */,
-				2CEF99392E925A5700CBA323 /* FirebaseAnalytics in Frameworks */,
-				2CEF99432E925A5700CBA323 /* FirebaseRemoteConfig in Frameworks */,
 				2CEF99412E925A5700CBA323 /* FirebaseCrashlytics in Frameworks */,
-				2CEF993B2E925A5700CBA323 /* FirebaseAnalyticsCore in Frameworks */,
 				2C079FBF2DB2505700B1EE0D /* RealmSwift in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
@@ -176,12 +168,8 @@
 			name = "Run Mile";
 			packageProductDependencies = (
 				2C079FBE2DB2505700B1EE0D /* RealmSwift */,
-				2CEF99382E925A5700CBA323 /* FirebaseAnalytics */,
-				2CEF993A2E925A5700CBA323 /* FirebaseAnalyticsCore */,
-				2CEF993C2E925A5700CBA323 /* FirebaseAnalyticsIdentitySupport */,
 				2CEF993E2E925A5700CBA323 /* FirebaseCore */,
 				2CEF99402E925A5700CBA323 /* FirebaseCrashlytics */,
-				2CEF99422E925A5700CBA323 /* FirebaseRemoteConfig */,
 			);
 			productName = "Run Mile";
 			productReference = 2CE46DF32DAE7780008C6FBC /* Run Mile.app */;
@@ -509,8 +497,8 @@
 				INFOPLIST_KEY_CFBundleDisplayName = "Run Mile";
 				INFOPLIST_KEY_LSApplicationCategoryType = "public.app-category.healthcare-fitness";
 				INFOPLIST_KEY_NSCameraUsageDescription = "러닝화 사진을 촬영해 신발 프로필 이미지로 등록하기 위해 카메라를 사용합니다.";
-				INFOPLIST_KEY_NSHealthShareUsageDescription = "러닝 운동 기록, 경로, 심박 데이터를 불러와 신발 마일리지 기록과 운동 분석에 사용합니다.";
-				INFOPLIST_KEY_NSHealthUpdateUsageDescription = "앱에서 운동 기록을 가져오기 위해서는 사용자의 허락이 필요합니다!";
+				INFOPLIST_KEY_NSHealthShareUsageDescription = "러닝 운동 기록, 경로, 거리, 시간, 페이스, 심박, 파워, 보폭 등 운동 분석에 필요한 건강 데이터를 불러옵니다.";
+				INFOPLIST_KEY_NSHealthUpdateUsageDescription = "디버그 시뮬레이터에서 테스트 운동 샘플을 생성하기 위해 건강 데이터 쓰기 권한을 사용합니다.";
 				INFOPLIST_KEY_UIApplicationSceneManifest_Generation = YES;
 				INFOPLIST_KEY_UIApplicationSupportsIndirectInputEvents = YES;
 				INFOPLIST_KEY_UILaunchScreen_Generation = YES;
@@ -553,8 +541,7 @@
 				INFOPLIST_KEY_CFBundleDisplayName = "Run Mile";
 				INFOPLIST_KEY_LSApplicationCategoryType = "public.app-category.healthcare-fitness";
 				INFOPLIST_KEY_NSCameraUsageDescription = "러닝화 사진을 촬영해 신발 프로필 이미지로 등록하기 위해 카메라를 사용합니다.";
-				INFOPLIST_KEY_NSHealthShareUsageDescription = "러닝 운동 기록, 경로, 심박 데이터를 불러와 신발 마일리지 기록과 운동 분석에 사용합니다.";
-				INFOPLIST_KEY_NSHealthUpdateUsageDescription = "앱에서 운동 기록을 가져오기 위해서는 사용자의 허락이 필요합니다!";
+				INFOPLIST_KEY_NSHealthShareUsageDescription = "러닝 운동 기록, 경로, 거리, 시간, 페이스, 심박, 파워, 보폭 등 운동 분석에 필요한 건강 데이터를 불러옵니다.";
 				INFOPLIST_KEY_UIApplicationSceneManifest_Generation = YES;
 				INFOPLIST_KEY_UIApplicationSupportsIndirectInputEvents = YES;
 				INFOPLIST_KEY_UILaunchScreen_Generation = YES;
@@ -719,21 +706,6 @@
 			package = 2C079FBD2DB2505700B1EE0D /* XCRemoteSwiftPackageReference "realm-swift" */;
 			productName = RealmSwift;
 		};
-		2CEF99382E925A5700CBA323 /* FirebaseAnalytics */ = {
-			isa = XCSwiftPackageProductDependency;
-			package = 2CEF98852E92584900CBA323 /* XCRemoteSwiftPackageReference "firebase-ios-sdk" */;
-			productName = FirebaseAnalytics;
-		};
-		2CEF993A2E925A5700CBA323 /* FirebaseAnalyticsCore */ = {
-			isa = XCSwiftPackageProductDependency;
-			package = 2CEF98852E92584900CBA323 /* XCRemoteSwiftPackageReference "firebase-ios-sdk" */;
-			productName = FirebaseAnalyticsCore;
-		};
-		2CEF993C2E925A5700CBA323 /* FirebaseAnalyticsIdentitySupport */ = {
-			isa = XCSwiftPackageProductDependency;
-			package = 2CEF98852E92584900CBA323 /* XCRemoteSwiftPackageReference "firebase-ios-sdk" */;
-			productName = FirebaseAnalyticsIdentitySupport;
-		};
 		2CEF993E2E925A5700CBA323 /* FirebaseCore */ = {
 			isa = XCSwiftPackageProductDependency;
 			package = 2CEF98852E92584900CBA323 /* XCRemoteSwiftPackageReference "firebase-ios-sdk" */;
@@ -743,11 +715,6 @@
 			isa = XCSwiftPackageProductDependency;
 			package = 2CEF98852E92584900CBA323 /* XCRemoteSwiftPackageReference "firebase-ios-sdk" */;
 			productName = FirebaseCrashlytics;
-		};
-		2CEF99422E925A5700CBA323 /* FirebaseRemoteConfig */ = {
-			isa = XCSwiftPackageProductDependency;
-			package = 2CEF98852E92584900CBA323 /* XCRemoteSwiftPackageReference "firebase-ios-sdk" */;
-			productName = FirebaseRemoteConfig;
 		};
 /* End XCSwiftPackageProductDependency section */
 	};

--- a/Run Mile/Data/CoreData/MigrationService.swift
+++ b/Run Mile/Data/CoreData/MigrationService.swift
@@ -37,7 +37,11 @@ final class MigrationService {
                 cdObject.nickname = object.nickname
                 cdObject.shoesName = object.shoesName
                 
+                var migratedWorkoutIDs: Set<UUID> = []
                 object.workouts.forEach {
+                    guard !migratedWorkoutIDs.contains($0.id) else { return }
+                    migratedWorkoutIDs.insert($0.id)
+
                     let cdWorkout = CDWorkoutDTO(context: context)
                     cdWorkout.id = $0.id
                     cdWorkout.date = $0.date

--- a/Run Mile/Data/DTO/Mapper.swift
+++ b/Run Mile/Data/DTO/Mapper.swift
@@ -16,11 +16,17 @@ enum DTOMapper {
         
         for shoe in dto {
             var workouts = [Workout]()
+            var workoutIDs: Set<UUID> = []
             
             for workout in shoe.workoutDTOArray {
                 guard let workoutID = workout.id else {
                     continue
                 }
+
+                guard !workoutIDs.contains(workoutID) else {
+                    continue
+                }
+                workoutIDs.insert(workoutID)
                 
                 // HealthKit에서 삭제된 운동은 CoreData 연결 정보만 남을 수 있으므로 신발 로딩을 막지 않고 제외합니다.
                 guard let workoutObject = try await healthStore.fetchSingleWorkoutData(id: workoutID) else {
@@ -52,11 +58,17 @@ enum DTOMapper {
     
     public static func CDWorkoutDTOtoEntities(_ dto: [CDWorkoutDTO]) async throws -> [Workout] {
         var resultArray: [Workout] = []
+        var workoutIDs: Set<UUID> = []
         
         for workout in dto {
             guard let workoutId = workout.id else {
                 continue
             }
+
+            guard !workoutIDs.contains(workoutId) else {
+                continue
+            }
+            workoutIDs.insert(workoutId)
             
             if let fetchedResult = try await healthStore.fetchSingleWorkoutData(id: workoutId) {
                 resultArray.append(.init(

--- a/Run Mile/Data/Health/WorkoutDataRepositoryImpl.swift
+++ b/Run Mile/Data/Health/WorkoutDataRepositoryImpl.swift
@@ -110,11 +110,12 @@ actor WorkoutDataRepositoryImpl: WorkoutDataRepository {
         
         for route in routes {
             let routeResult = try await withCheckedThrowingContinuation { (continuation: CheckedContinuation<[CLLocation], any Error>) in
+                let oneShotContinuation = OneShotContinuation(continuation)
                 var fetchedLocations: [CLLocation] = []
                 
-                let locationQuery = HKWorkoutRouteQuery(route: route) { query, locations, done, error in
+                let locationQuery = HKWorkoutRouteQuery(route: route) { _, locations, done, error in
                     if let error = error {
-                        continuation.resume(throwing: error)
+                        oneShotContinuation.resume(throwing: error)
                         return
                     }
                     if let locations = locations {
@@ -122,7 +123,7 @@ actor WorkoutDataRepositoryImpl: WorkoutDataRepository {
                     }
                     
                     if done {
-                        continuation.resume(returning: fetchedLocations)
+                        oneShotContinuation.resume(returning: fetchedLocations)
                     }
                 }
                 store.execute(locationQuery)
@@ -414,11 +415,12 @@ actor WorkoutDataRepositoryImpl: WorkoutDataRepository {
         let predicate = HKQuery.predicateForObject(with: sample.uuid)
         
         return try await withCheckedThrowingContinuation { continuation in
+            let oneShotContinuation = OneShotContinuation(continuation)
             var samples: [WorkoutDistanceSample] = []
             
             let query = HKQuantitySeriesSampleQuery(quantityType: type, predicate: predicate) { _, quantity, dateInterval, _, done, error in
                 if let error {
-                    continuation.resume(throwing: error)
+                    oneShotContinuation.resume(throwing: error)
                     return
                 }
                 
@@ -437,7 +439,7 @@ actor WorkoutDataRepositoryImpl: WorkoutDataRepository {
                 }
                 
                 if done {
-                    continuation.resume(returning: samples)
+                    oneShotContinuation.resume(returning: samples)
                 }
             }
             
@@ -449,11 +451,12 @@ actor WorkoutDataRepositoryImpl: WorkoutDataRepository {
         let predicate = HKQuery.predicateForObject(with: sample.uuid)
         
         return try await withCheckedThrowingContinuation { continuation in
+            let oneShotContinuation = OneShotContinuation(continuation)
             var points: [RunningMetricPoint] = []
             
             let query = HKQuantitySeriesSampleQuery(quantityType: type, predicate: predicate) { [weak self] _, quantity, dateInterval, _, done, error in
                 if let error {
-                    continuation.resume(throwing: error)
+                    oneShotContinuation.resume(throwing: error)
                     return
                 }
                 
@@ -464,7 +467,7 @@ actor WorkoutDataRepositoryImpl: WorkoutDataRepository {
                 }
                 
                 if done {
-                    continuation.resume(returning: points)
+                    oneShotContinuation.resume(returning: points)
                 }
             }
             
@@ -505,6 +508,37 @@ actor WorkoutDataRepositoryImpl: WorkoutDataRepository {
         return .init(timestamp: timestamp, value: value, unit: unit)
     }
 }
+
+
+private final class OneShotContinuation<Value>: @unchecked Sendable {
+    private let lock = NSLock()
+    private var continuation: CheckedContinuation<Value, any Error>?
+
+    init(_ continuation: CheckedContinuation<Value, any Error>) {
+        self.continuation = continuation
+    }
+
+    func resume(returning value: Value) {
+        resume(with: .success(value))
+    }
+
+    func resume(throwing error: any Error) {
+        resume(with: .failure(error))
+    }
+
+    private func resume(with result: Result<Value, any Error>) {
+        lock.lock()
+        guard let continuation else {
+            lock.unlock()
+            return
+        }
+
+        self.continuation = nil
+        lock.unlock()
+        continuation.resume(with: result)
+    }
+}
+
 
 #if DEBUG
 private extension WorkoutDataRepositoryImpl {

--- a/Run Mile/Data/Health/WorkoutDataRepositoryImpl.swift
+++ b/Run Mile/Data/Health/WorkoutDataRepositoryImpl.swift
@@ -53,7 +53,7 @@ actor WorkoutDataRepositoryImpl: WorkoutDataRepository {
         let unifiedVerticalOscillation = DTOMapper.normalizeData(workout: workout, data: verticalOscillation)
         let unifiedGroundContactTime = DTOMapper.normalizeData(workout: workout, data: groundContactTime)
         let unifiedStrideLength = DTOMapper.normalizeData(workout: workout, data: strideLength)
-        let avgCadence = cadence.reduce(0.0, { $0 + $1.value }) / (workout.duration / 60)
+        let avgCadence = makeAverageCadence(points: cadence, duration: workout.duration)
         
         result.heartRate = unifiedHeartRate
         result.runningPace = unifiedPace
@@ -66,6 +66,27 @@ actor WorkoutDataRepositoryImpl: WorkoutDataRepository {
         result.routes = route
         
         return result
+    }
+
+    /// 케이던스 샘플이 실제로 존재할 때만 분당 보폭 수를 계산합니다.
+    private func makeAverageCadence(points: [RunningMetricPoint], duration: TimeInterval) -> Double? {
+        guard !points.isEmpty,
+              duration > 0 else {
+            return nil
+        }
+
+        let totalStepCount = points
+            .map(\.value)
+            .filter { $0.isFinite && $0 > 0 }
+            .reduce(0.0, +)
+        let durationMinutes = duration / 60
+
+        guard totalStepCount > 0,
+              durationMinutes > 0 else {
+            return nil
+        }
+
+        return totalStepCount / durationMinutes
     }
     
     

--- a/Run Mile/Data/Shoes/ShoesDataRepositoryImpl.swift
+++ b/Run Mile/Data/Shoes/ShoesDataRepositoryImpl.swift
@@ -88,29 +88,35 @@ actor ShoesDataRepositoryImpl: ShoesDataRepository {
                 }
 
                 let existingWorkouts = (entity.workouts as? Set<CDWorkoutDTO>) ?? []
-                var workoutMap = Dictionary<UUID, CDWorkoutDTO>(
-                    uniqueKeysWithValues: existingWorkouts.compactMap { entity in
-                        guard let id = entity.id else { return nil }
-                        return (id, entity) // Key: UUID, Value: Entity
-                    }
-                )
+                var workoutMap: [UUID: CDWorkoutDTO] = [:]
 
-                for workoutModel in shoes.workouts {
+                for workoutEntity in existingWorkouts {
+                    guard let id = workoutEntity.id else {
+                        context.delete(workoutEntity)
+                        continue
+                    }
+
+                    if workoutMap[id] == nil {
+                        workoutMap[id] = workoutEntity
+                    } else {
+                        context.delete(workoutEntity)
+                    }
+                }
+
+                var updatedWorkoutIDs: Set<UUID> = []
+                for workoutModel in shoes.workouts where !updatedWorkoutIDs.contains(workoutModel.id) {
+                    updatedWorkoutIDs.insert(workoutModel.id)
                     let workoutEntity: CDWorkoutDTO
 
                     if let existing = workoutMap[workoutModel.id] {
-                        // A. 이미 존재하면 -> 가져오고, Map에서 제거 (처리됨 표시)
                         workoutEntity = existing
                         workoutMap.removeValue(forKey: workoutModel.id)
                     } else {
-                        // B. 없으면 -> 새로 생성 및 부모 연결
                         workoutEntity = CDWorkoutDTO(context: context)
                         workoutEntity.id = workoutModel.id
-                        // 관계 연결 (중요)
                         workoutEntity.shoes = entity
                     }
 
-                    // 속성 업데이트 (공통)
                     workoutEntity.distance = workoutModel.distance
                     workoutEntity.date = workoutModel.date
                 }

--- a/Run Mile/Presentation/0.Main/MainTabView.swift
+++ b/Run Mile/Presentation/0.Main/MainTabView.swift
@@ -96,19 +96,22 @@ struct MainTabView: View {
 
     @ViewBuilder
     private var customSheetOverlay: some View {
-        if let customSheet = navigationCoordinator.customSheet {
-            ZStack(alignment: .bottom) {
+        ZStack(alignment: .bottom) {
+            if navigationCoordinator.customSheet != nil {
                 Color.black.opacity(0.24)
                     .ignoresSafeArea()
-
-                screenFactory.makeCustomSheet(for: customSheet)
+                    .transition(.opacity)
             }
-            .transition(.move(edge: .bottom).combined(with: .opacity))
-            .ignoresSafeArea(edges: .bottom)
-            .animation(
-                .spring(response: 0.28, dampingFraction: 0.86),
-                value: navigationCoordinator.customSheet != nil
-            )
+
+            if let customSheet = navigationCoordinator.customSheet {
+                screenFactory.makeCustomSheet(for: customSheet)
+                    .transition(.move(edge: .bottom).combined(with: .opacity))
+            }
         }
+        .ignoresSafeArea(edges: .bottom)
+        .animation(
+            .spring(response: 0.34, dampingFraction: 0.88),
+            value: navigationCoordinator.customSheet != nil
+        )
     }
 }

--- a/Run Mile/Presentation/1.Shoes/1-1.AddShoes/AddShoesViewModel.swift
+++ b/Run Mile/Presentation/1.Shoes/1-1.AddShoes/AddShoesViewModel.swift
@@ -210,9 +210,19 @@ extension AddShoesViewModel {
     
     @MainActor
     public func saveButtonTapped() {
+        guard let image else {
+            NavigationCoordinator.shared.push(.init(
+                title: "신발 사진을 추가해주세요.",
+                message: nil,
+                firstButton: .cancel(title: "확인", action: {}),
+                secondButton: nil
+            ))
+            return
+        }
+
         let shoes = Shoes(
             id: .init(),
-            image: self.image!,
+            image: image,
             shoesName: self.effectiveShoesName,
             nickname: self.usage, // Usage maps to nickname
             goalMileage: Double(self.goalMileage) ?? 0.0,

--- a/Run Mile/Presentation/1.Shoes/ShoesListView.swift
+++ b/Run Mile/Presentation/1.Shoes/ShoesListView.swift
@@ -15,43 +15,41 @@ struct ShoesListView: View {
     }
     
     var body: some View {
-        NavigationStack {
-            ScrollView {
-                LazyVStack(spacing: 20) {
-                    monthlySummaryView
-                    
-                    HStack {
-                        Text("내 신발장")
+        ScrollView {
+            LazyVStack(spacing: 20) {
+                monthlySummaryView
+
+                HStack {
+                    Text("내 신발장")
+                        .font(.title2)
+                        .fontWeight(.bold)
+                    Spacer()
+                    Button(action: {
+                        viewModel.addShoesButtonTapped()
+                    }) {
+                        Image(systemName: "plus.circle.fill")
                             .font(.title2)
-                            .fontWeight(.bold)
-                        Spacer()
-                        Button(action: {
-                            viewModel.addShoesButtonTapped()
-                        }) {
-                            Image(systemName: "plus.circle.fill")
-                                .font(.title2)
-                                .foregroundStyle(RunMileColor.primary)
-                        }
-                    }
-                    .padding(.horizontal)
-                    .padding(.top, 10)
-                    
-                    ForEach(viewModel.shoeCardItems) { item in
-                        ShoeCardView(item: item)
-                            .padding(.horizontal)
-                            .onTapGesture {
-                                viewModel.shoesCellTapped(item.shoe)
-                            }
-                    }
-                    
-                    if viewModel.shoes.isEmpty {
-                        emptyStateView
+                            .foregroundStyle(RunMileColor.primary)
                     }
                 }
-                .padding(.bottom, 20)
+                .padding(.horizontal)
+                .padding(.top, 10)
+
+                ForEach(viewModel.shoeCardItems) { item in
+                    ShoeCardView(item: item)
+                        .padding(.horizontal)
+                        .onTapGesture {
+                            viewModel.shoesCellTapped(item.shoe)
+                        }
+                }
+
+                if viewModel.shoes.isEmpty {
+                    emptyStateView
+                }
             }
-            .background(RunMileColor.background)
+            .padding(.bottom, 20)
         }
+        .background(RunMileColor.background)
         .onAppear {
             viewModel.onAppear()
         }
@@ -102,6 +100,8 @@ struct ShoesListView: View {
 
 #if DEBUG
 #Preview {
-    ShoesListView(viewModel: PreviewDIContainer().makeShoesListViewModel())
+    NavigationStack {
+        ShoesListView(viewModel: PreviewDIContainer().makeShoesListViewModel())
+    }
 }
 #endif

--- a/Run Mile/Presentation/2.Workout/2-3.WorkoutDetail/WorkoutDetailViewModel.swift
+++ b/Run Mile/Presentation/2.Workout/2-3.WorkoutDetail/WorkoutDetailViewModel.swift
@@ -630,16 +630,7 @@ extension WorkoutDetailViewModel {
 extension WorkoutDetailViewModel {
     public var avgHeartRate: String? {
         guard let workoutDetail = workoutDetail else { return nil }
-
-        var count = 0
-        let results = workoutDetail.heartRate
-            .compactMap { $0.value }
-            .reduce(0) {
-                count += 1
-                return $0 + $1
-            }
-
-        return String(format: "%.0f", results / Double(count))
+        return formattedAverageMetricValue(from: workoutDetail.heartRate, format: "%.0f")
     }
 
     public var avgPace: String {
@@ -647,74 +638,53 @@ extension WorkoutDetailViewModel {
     }
 
     public var avgPower: String? {
-        guard let workoutDetail = workoutDetail,
-              !workoutDetail.power.isEmpty else { return nil }
-
-        var count = 0
-        let results = workoutDetail.power
-            .compactMap { $0.value }
-            .reduce(0) {
-                count += 1
-                return $0 + $1
-            }
-
-        return String(format: "%.0f", results / Double(count))
+        guard let workoutDetail = workoutDetail else { return nil }
+        return formattedAverageMetricValue(from: workoutDetail.power, format: "%.0f")
     }
 
     public var avgCadence: String? {
-        guard let cadence = workoutDetail?.cadence else { return nil }
+        guard let cadence = workoutDetail?.cadence,
+              cadence.isFinite,
+              cadence > 0 else { return nil }
 
         return String(format: "%.0f", cadence)
     }
 
     public var avgVerticalOscillation: String? {
-        guard let workoutDetail = workoutDetail,
-              !workoutDetail.verticalOscillation.isEmpty else { return nil }
-
-        var count = 0
-        let results = workoutDetail.verticalOscillation
-            .compactMap { $0.value }
-            .reduce(0) {
-                count += 1
-                return $0 + $1
-            }
-
-        return String(format: "%.1f", results / Double(count))
+        guard let workoutDetail = workoutDetail else { return nil }
+        return formattedAverageMetricValue(from: workoutDetail.verticalOscillation, format: "%.1f")
     }
 
     public var avgGroundContactTime: String? {
-        guard let workoutDetail = workoutDetail,
-              !workoutDetail.groundContactTime.isEmpty else { return nil }
-
-        var count = 0
-        let results = workoutDetail.groundContactTime
-            .compactMap { $0.value }
-            .reduce(0) {
-                count += 1
-                return $0 + $1
-            }
-
-        return String(format: "%.0f", results / Double(count))
+        guard let workoutDetail = workoutDetail else { return nil }
+        return formattedAverageMetricValue(from: workoutDetail.groundContactTime, format: "%.0f")
     }
 
     public var avgStrideLength: String? {
-        guard let workoutDetail = workoutDetail,
-              !workoutDetail.strideLength.isEmpty else { return nil }
-
-        var count = 0
-        let results = workoutDetail.strideLength
-            .compactMap { $0.value }
-            .reduce(0) {
-                count += 1
-                return $0 + $1
-            }
-
-        return String(format: "%.1f", results / Double(count))
+        guard let workoutDetail = workoutDetail else { return nil }
+        return formattedAverageMetricValue(from: workoutDetail.strideLength, format: "%.1f")
     }
 
     public var elevationGain: String? {
-        guard let routeData = workoutDetail?.routes else { return nil }
-        return routeData.calculateTotalElevationGain()
+        guard let routeData = workoutDetail?.routes,
+              !routeData.isEmpty else { return nil }
+
+        let elevationGain = routeData.calculateTotalElevationGain()
+        return elevationGain.isEmpty ? nil : elevationGain
+    }
+
+    /// 선택 metric의 평균 표시값을 계산하고, 유효한 값이 없으면 카드를 숨길 수 있도록 nil을 반환합니다.
+    private func formattedAverageMetricValue(from samples: [UnifiedWorkoutDetailData], format: String) -> String? {
+        let values = samples
+            .compactMap(\.value)
+            .filter { $0.isFinite }
+
+        guard !values.isEmpty else {
+            return nil
+        }
+
+        let average = values.reduce(0, +) / Double(values.count)
+        return String(format: format, average)
     }
 }
 

--- a/Run MileTests/ChooseShoesUseCaseTests.swift
+++ b/Run MileTests/ChooseShoesUseCaseTests.swift
@@ -17,7 +17,7 @@ struct ChooseShoesUseCaseTests {
         let firstShoes = makeShoes(nickname: "이전 신발", workouts: [workout])
         let targetShoes = makeShoes(nickname: "새 신발")
         let repository = FakeChooseShoesRepository(shoes: [firstShoes, targetShoes])
-        let useCase = DefaultChooseShoesUseCase(repository: repository)
+        let useCase = makeUseCase(repository: repository)
 
         let conflictCount = try await useCase.registeredWorkoutConflictCount(
             targetShoes: targetShoes,
@@ -32,7 +32,7 @@ struct ChooseShoesUseCaseTests {
         let firstShoes = makeShoes(nickname: "이전 신발", workouts: [workout])
         let targetShoes = makeShoes(nickname: "새 신발")
         let repository = FakeChooseShoesRepository(shoes: [firstShoes, targetShoes])
-        let useCase = DefaultChooseShoesUseCase(repository: repository)
+        let useCase = makeUseCase(repository: repository)
 
         try await useCase.registerWorkouts(
             shoes: targetShoes,
@@ -52,7 +52,7 @@ struct ChooseShoesUseCaseTests {
         let workout = makeWorkout()
         let targetShoes = makeShoes(nickname: "현재 신발", workouts: [workout])
         let repository = FakeChooseShoesRepository(shoes: [targetShoes])
-        let useCase = DefaultChooseShoesUseCase(repository: repository)
+        let useCase = makeUseCase(repository: repository)
 
         try await useCase.registerWorkouts(
             shoes: targetShoes,
@@ -71,7 +71,7 @@ struct ChooseShoesUseCaseTests {
         let firstShoes = makeShoes(nickname: "이전 신발", workouts: [workout])
         let targetShoes = makeShoes(nickname: "새 신발")
         let repository = FakeChooseShoesRepository(shoes: [firstShoes, targetShoes])
-        let useCase = DefaultChooseShoesUseCase(repository: repository)
+        let useCase = makeUseCase(repository: repository)
 
         try await useCase.registerWorkouts(
             shoes: targetShoes,
@@ -86,6 +86,14 @@ struct ChooseShoesUseCaseTests {
         #expect(updatedFirstShoes.workouts.map(\.id) == [workout.id])
         #expect(updatedTargetShoes.workouts.isEmpty)
     }
+}
+
+
+private func makeUseCase(repository: ShoesDataRepository) -> DefaultChooseShoesUseCase {
+    DefaultChooseShoesUseCase(
+        repository: repository,
+        mileageGoalNotificationService: FakeMileageGoalNotificationService()
+    )
 }
 
 
@@ -156,6 +164,15 @@ private actor FakeChooseShoesRepository: ShoesDataRepository {
     }
 
     func updateSelectedShoes(shoes: Shoes) async {}
+}
+
+
+private actor FakeMileageGoalNotificationService: MileageGoalNotificationService {
+    private(set) var requestedShoes: [Shoes] = []
+
+    func requestGoalReachedNotification(shoes: Shoes) async {
+        requestedShoes.append(shoes)
+    }
 }
 
 


### PR DESCRIPTION
close #87

## Summary
이 PR은 출시 전 심사/QA 과정에서 리젝 또는 오류로 이어질 수 있는 잠재 이슈를 수정합니다. 권한 안내와 약관 문구를 정리하고, 중복 NavigationStack 제거, 데이터가 없는 운동 상세 섹션 숨김, 커스텀 시트 액션 및 테스트 코드를 보강했습니다.

## Key Changes

### 1. Review & Permission Copy Update
- 권한 허용 메시지를 수정해 사용자에게 필요한 안내가 더 명확히 전달되도록 했습니다.
- `PrivacyPolicy.md` 약관 내용을 정리했습니다.
- 출시 전 심사에서 오해가 생길 수 있는 문구와 흐름을 점검했습니다.

### 2. Navigation & Sheet Flow Fixes
- 중복 `NavigationStack` 구성을 제거해 navigation 계층이 중첩되지 않도록 수정했습니다.
- 커스텀 시트 액션 흐름을 수정해 버튼 동작과 상태 변경이 더 안정적으로 처리되도록 했습니다.

### 3. Workout Detail Empty State Handling
- 운동 상세 화면에서 데이터가 없는 섹션은 표시되지 않도록 ViewModel 로직을 수정했습니다.
- HealthKit 상세 데이터 fetch 및 DTO mapping 과정에서 잠재적으로 오류가 발생할 수 있는 부분을 보강했습니다.

### 4. Data & Test Stabilization
- CoreData migration, shoes repository, workout repository의 잠재 오류 케이스를 보강했습니다.
- `ChooseShoesUseCaseTests`를 수정해 변경된 신발 선택/등록 흐름을 검증하도록 정리했습니다.
- Xcode project 설정에서 불필요하거나 변경된 테스트/파일 참조를 정리했습니다.

## Impact
- 출시 전 리젝 가능성이 있는 문구, 권한 안내, navigation 구조 문제가 줄어듭니다.
- 운동 상세 화면에서 비어 있는 데이터 섹션이 노출되지 않아 UI 완성도가 개선됩니다.
- 데이터 매핑/저장 흐름의 예외 처리와 테스트 안정성이 보강됩니다.

## Validation
- 변경 사항은 커밋 기록과 `origin/develop...HEAD` diff 기준으로 확인했습니다.
- 로컬 빌드/테스트는 별도로 실행하지 않았습니다.