### PR TITLE
[Fix] 미니맵 히어로 뷰 UI 수정

### DIFF
--- a/Run Mile/Presentation/2.Workout/2-3.WorkoutDetail/Sections/HeaderSummarySection.swift
+++ b/Run Mile/Presentation/2.Workout/2-3.WorkoutDetail/Sections/HeaderSummarySection.swift
@@ -125,7 +125,7 @@ struct HeaderSummarySection: View {
 
     private var headerContent: some View {
         GeometryReader { geometry in
-            let valueFontSize = headerMetricValueFontSize(for: geometry.size.width)
+            let metricLayout = HeaderMetricLayout(width: geometry.size.width)
 
             VStack(alignment: .leading, spacing: 4) {
                 Text(viewModel.workoutStartDate)
@@ -138,19 +138,48 @@ struct HeaderSummarySection: View {
                     .fontWeight(.black)
                     .foregroundStyle(.white)
 
-                HStack(spacing: 20) {
-                    HeaderMetric(value: viewModel.distance, label: "킬로미터", valueFontSize: valueFontSize)
-                    HeaderMetric(value: viewModel.elapsedTime, label: "시간", valueFontSize: valueFontSize)
-                    HeaderMetric(value: viewModel.calories, label: "KCAL", valueFontSize: valueFontSize)
+                HStack(alignment: .bottom, spacing: metricLayout.spacing) {
+                    HeaderMetric(value: viewModel.distance, label: "킬로미터", layout: metricLayout)
+                    HeaderMetric(value: viewModel.elapsedTime, label: "시간", layout: metricLayout)
+                        .layoutPriority(1)
+                    HeaderMetric(value: viewModel.calories, label: "KCAL", layout: metricLayout)
                 }
-                .padding(.top, 10)
+                .padding(.top, metricLayout.topPadding)
             }
             .frame(maxWidth: .infinity, maxHeight: .infinity, alignment: .bottomLeading)
         }
     }
+}
 
-    private func headerMetricValueFontSize(for width: CGFloat) -> CGFloat {
-        width < 320 ? 28 : 32
+private struct HeaderMetricLayout {
+    let valueFontSize: CGFloat
+    let labelFont: Font
+    let spacing: CGFloat
+    let topPadding: CGFloat
+
+    init(width: CGFloat) {
+        switch width {
+        case ..<285:
+            valueFontSize = 22
+            labelFont = .caption2
+            spacing = RunMileSpacing.small
+            topPadding = RunMileSpacing.small
+        case ..<325:
+            valueFontSize = 24
+            labelFont = .caption2
+            spacing = RunMileSpacing.small
+            topPadding = RunMileSpacing.small
+        case ..<365:
+            valueFontSize = 28
+            labelFont = .caption
+            spacing = RunMileSpacing.medium
+            topPadding = RunMileSpacing.small
+        default:
+            valueFontSize = 32
+            labelFont = .caption
+            spacing = RunMileSpacing.large
+            topPadding = RunMileSpacing.medium
+        }
     }
 }
 
@@ -158,18 +187,23 @@ struct HeaderSummarySection: View {
 private struct HeaderMetric: View {
     let value: String
     let label: String
-    let valueFontSize: CGFloat
+    let layout: HeaderMetricLayout
 
     var body: some View {
-        VStack(alignment: .leading) {
+        VStack(alignment: .leading, spacing: 0) {
             Text(value)
-                .font(.system(size: valueFontSize, weight: .bold, design: .rounded))
+                .font(Font(UIFont.systemFont(ofSize: layout.valueFontSize, weight: .bold, width: .condensed)))
                 .foregroundStyle(.white)
+                .lineLimit(1)
+                .minimumScaleFactor(0.82)
+                .allowsTightening(true)
 
             Text(label)
-                .font(.caption)
+                .font(layout.labelFont)
                 .fontWeight(.medium)
                 .foregroundStyle(.white.opacity(0.8))
+                .lineLimit(1)
+                .minimumScaleFactor(0.9)
         }
     }
 }


### PR DESCRIPTION
close #89

## Summary
이 PR은 운동 상세 화면의 미니맵 히어로 영역에서 주요 지표가 다양한 너비에서도 안정적으로 보이도록 레이아웃을 수정했습니다. 화면 폭에 따라 지표 값 폰트, 라벨 폰트, 간격, 상단 여백을 조정해 작은 화면에서 텍스트가 겹치거나 잘리는 문제를 줄였습니다.

## Key Changes

### 1. Header Metric Layout 추가
- `HeaderMetricLayout`을 추가해 미니맵 히어로 영역의 너비별 지표 레이아웃 값을 계산하도록 했습니다.
- 화면 폭 구간에 따라 value font size, label font, metric spacing, top padding을 다르게 적용했습니다.

### 2. Header Metric 표시 안정화
- 거리, 시간, 칼로리 지표가 좁은 화면에서도 한 줄로 유지되도록 `lineLimit`, `minimumScaleFactor`, `allowsTightening`을 적용했습니다.
- 긴 시간 값이 다른 지표보다 우선적으로 공간을 확보할 수 있도록 layout priority를 조정했습니다.
- 지표 폰트를 condensed width 기반으로 변경해 좁은 화면에서 가독성과 수용성을 개선했습니다.

## Impact
- 작은 기기에서도 미니맵 히어로 뷰의 운동 지표가 더 안정적으로 표시됩니다.
- 거리/시간/칼로리 정보가 겹치거나 잘리는 가능성이 줄어듭니다.
- 기존 디자인 무드를 유지하면서 화면 크기별 UI 대응력이 개선됩니다.

## Validation
- 변경 사항은 커밋 기록과 `origin/develop...HEAD` diff 기준으로 확인했습니다.
- 로컬 빌드/테스트는 별도로 실행하지 않았습니다.